### PR TITLE
feat(snippets): Add a Shiny Express app snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The extension now supports Shiny for R apps. (#30)
 - The [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) is now a soft dependency and is no longer installed by default with the Shiny for VS Code extension. (#30)
+- Added a new `shinyexpress` snippet to quickly create a basic Shiny Express app in Python. (#42)
 
 ## 0.1.6
 

--- a/snippets/shiny.json
+++ b/snippets/shiny.json
@@ -33,7 +33,7 @@
       "",
       "@render.text",
       "def txt():",
-      "\t\treturn f\"n*2 is {input.n() * 2}\"",
+      "\treturn f\"n*2 is {input.n() * 2}\"",
       ""
     ],
     "description": "Basic Shiny Express app skeleton"

--- a/snippets/shiny.json
+++ b/snippets/shiny.json
@@ -20,7 +20,23 @@
       "app = App(app_ui, server)",
       ""
     ],
-    "description": "Basic Shiny app skeleton"
+    "description": "Basic Shiny Core app skeleton"
+  },
+  "Shiny Express application": {
+    "scope": "python",
+    "prefix": "shinyexpress",
+    "body": [
+      "from shiny.express import input, render, ui",
+      "",
+      "ui.input_slider(\"n\", \"N\", 0, 100, 20)",
+      "",
+      "",
+      "@render.text",
+      "def txt():",
+      "\t\treturn f\"n*2 is {input.n() * 2}\"",
+      ""
+    ],
+    "description": "Basic Shiny Express app skeleton"
   },
   "Shiny module": {
     "scope": "python",


### PR DESCRIPTION
Adds a snippet for `shinyexpress` using the default example on https://shinylive.io/py/editor

```py
from shiny.express import input, render, ui

ui.input_slider("n", "N", 0, 100, 20)


@render.text
def txt():
    return f"n*2 is {input.n() * 2}"

```