### PR TITLE
feat: Support Shinylive export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - The [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) is now a soft dependency and is no longer installed by default with the Shiny for VS Code extension. (#30)
 - Added a new setting, `shiny.previewType`, to control where the Shiny app preview should be opened. (#40)
 - Added a new `shinyexpress` snippet to quickly create a basic Shiny Express app in Python. (#42)
+- The extension can now create Shinylive links or save apps from Shinylive links (#44):
+  - **Create ShinyLive Link from Active File** creates a Shinylive link from the active file (Command Palette).
+  - **Create ShinyLive Link from Selected Files** creates a Shinylive link from the selected files or directories in the right-click context menu of the File Explorer.
+  - **Save App from Shinylive Link** saves an app and its files from a Shinylive link (Command Palette).
 
 ## 0.1.6
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can use the extension to create shareable links to your apps using [Shinyliv
 
 The Shiny extension will ask you which app mode you want to use (display the _app_ or show an _editor_ next to the app) and what action to take (to _open_ or _copy_ the link).You can also configure these options in the extension settings.
 
-For the reverse operation, use the **Save App from Shinylive Link** command in the command palette to save an app and its files from a Shinylive link. You'll be prompted to paste the Shinylive link and then to choose a directory where the app will be saved in your workspace.
+For the reverse operation, use the **Save App from Shinylive Link** command in the command palette to save an app and its files from a Shinylive link. You'll be prompted to paste the Shinylive link and then to choose where the app will be saved in your workspace.
 
 ## Extension Settings
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is an extension to help launch [Shiny applications](https://shiny.posit.co)
 
 ## Features
 
+### Run and Debug Shiny Apps
+
 The main features of this extension are additional options in the Run button menu when editing an `app.py` or `app.R` file to "Run Shiny App" or "Debug Shiny App" (Python only).
 
 ![Run app](https://shiny.posit.co/py/docs/assets/vscode.png)
@@ -14,6 +16,20 @@ It also provides a couple of code snippets in both Python and R:
 - `shinymod` for creating a new Shiny module
 
 For a complete Shiny for Python experience in VS Code, please [visit our docs for more information](https://shiny.posit.co/py/docs/install-create-run.html#vs-code), including instructions for configuring the type checker and debugger for use with Shiny.
+
+### Shinylive
+
+You can use the extension to create shareable links to your apps using [Shinylive](https://shinylive.io), a free service for sharing Shiny apps via static hosting. Shinylive links encode the app's code and data in the URL, so you can share your app with others without needing to deploy it to a server. When the link is opened, the app runs in the user's browser using special version of Python or R that can run in the browser.
+
+**To create a Shinylive link from your app**, you have two choices:
+
+1. For single-file apps, e.g. `app.py` or `app.R`, run the **Create ShinyLive Link from Active File** from the command palette with the app file open and active.
+
+2. For multi-file apps, select all of the files or directories you want to include in your Shinylive app in the Explorer pane. Then right click on the selection and choose **Create ShinyLive Link from Selected Files**.
+
+The Shiny extension will ask you which app mode you want to use (display the _app_ or show an _editor_ next to the app) and what action to take (to _open_ or _copy_ the link).You can also configure these options in the extension settings.
+
+For the reverse operation, use the **Save App from Shinylive Link** command in the command palette to save an app and its files from a Shinylive link. You'll be prompted to paste the Shinylive link and then to choose a directory where the app will be saved in your workspace.
 
 ## Extension Settings
 
@@ -30,3 +46,10 @@ Note that there is no setting for Python executable path or virtual environment.
 
 - `shiny.r.port`: The port number to listen on when running a Shiny app. (By default, 0, which will choose a random port for each workspace.)
 - `shiny.r.devmode`: When `true` (default), Shiny for R apps are launched [in developer mode](https://shiny.posit.co/r/reference/shiny/latest/devmode.html).
+
+### Shinylive
+
+- `shiny.shinylive.appMode`: Should the Shinylive link open the app in `"app"` mode, showing only the app and an optional header, or in `"editor"` mode with the app alongside an editor and console pane. The default is `"ask"`, which prompts you each time you create Shinylive link.
+- `shiny.includeHeader`: Include the "Shiny" header in the Shinylive link when opening in app mode?
+- `shiny.shinylive.openAction`: What action should be taken when opening a Shinylive link? Options are `"open"` to open the link in an external browser, `"copy"` the link to the clipboard, or `"ask"`. The default is `"ask"`, which prompts you each time you create a Shinylive link.
+- `shiny.shinylive.host`: The Shinylive host used when creating a Shinylive link. The default is `"https://shinylive.io"`, which uses the latest released version of Shiny in Python or R. Or `"https://posit-dev.github.io/shinylive"`, which uses the latest development version of Shiny in Python or R.

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
           "default": true,
           "markdownDescription": "Enable dev mode when running a Shiny for R app by running `shiny::devmode()` before launching the app."
         },
-        "shiny.shinylive.mode": {
+        "shiny.shinylive.appMode": {
           "type": "string",
           "default": "ask",
           "description": "Which Shinylive mode to use when creating a Shinylive app.",
@@ -169,7 +169,7 @@
             "Editor mode displays the app alongside an editor and console."
           ]
         },
-        "shiny.shinylive.action": {
+        "shiny.shinylive.openAction": {
           "type": "string",
           "default": "ask",
           "description": "Choose the default action upon creating a Shinylive link.",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,13 @@
         "title": "Run Shiny App",
         "icon": "$(play)",
         "enablement": "editorLangId == r && shellExecutionSupported"
+      },
+      {
+        "category": "Shiny",
+        "command": "shiny.shinylive.createFromActiveFile",
+        "title": "Send Current File to ShinyLive",
+        "icon": "$(link)",
+        "enablement": "editorLangId == python || editorLangId == r"
       }
     ],
     "menus": {
@@ -121,6 +128,31 @@
           "type": "boolean",
           "default": true,
           "description": "Enable dev mode when running a Shiny for R app by running `shiny::devmode()` before launching the app."
+        },
+        "shiny.shinylive.mode": {
+          "type": "string",
+          "default": "ask",
+          "description": "Which Shinylive mode to use when creating a Shinylive app.",
+          "enum": [
+            "ask",
+            "app",
+            "editor"
+          ]
+        },
+        "shiny.shinylive.action": {
+          "type": "string",
+          "default": "ask",
+          "description": "Choose the default action upon creating a Shinylive link.",
+          "enum": [
+            "ask",
+            "open",
+            "copy"
+          ]
+        },
+        "shiny.shinylive.includeHeader": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include the Shiny header when creating Shinylive app links."
         }
       }
     }
@@ -152,6 +184,7 @@
     "@types/winreg": "^1.2.36",
     "@vscode/python-extension": "^1.0.5",
     "fs": "^0.0.1-security",
+    "lz-string": "^1.5.0",
     "winreg": "^1.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,8 +60,14 @@
         "category": "Shiny",
         "command": "shiny.shinylive.createFromActiveFile",
         "title": "Send Current File to ShinyLive",
-        "icon": "$(link)",
+        "icon": "$(cloud-upload)",
         "enablement": "editorLangId == python || editorLangId == r"
+      },
+      {
+        "category": "Shiny",
+        "command": "shiny.shinylive.saveAppFromUrl",
+        "title": "Save App from Shinylive Link",
+        "icon": "$(cloud-download)"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -68,9 +68,21 @@
         "command": "shiny.shinylive.saveAppFromUrl",
         "title": "Save App from Shinylive Link",
         "icon": "$(cloud-download)"
+      },
+      {
+        "category": "Shiny",
+        "command": "shiny.shinylive.createFromExplorer",
+        "title": "Create Shinylive Link from Selected Files",
+        "icon": "$(cloud-upload)"
       }
     ],
     "menus": {
+      "explorer/context": [
+        {
+          "command": "shiny.shinylive.createFromExplorer",
+          "group": "shinylive"
+        }
+      ],
       "editor/title/run": [
         {
           "command": "shiny.python.runApp",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       {
         "category": "Shiny",
         "command": "shiny.shinylive.createFromActiveFile",
-        "title": "Send Current File to ShinyLive",
+        "title": "Create ShinyLive Link from Active File",
         "icon": "$(cloud-upload)",
         "enablement": "editorLangId == python || editorLangId == r"
       },
@@ -202,6 +202,7 @@
     "@types/winreg": "^1.2.36",
     "@vscode/python-extension": "^1.0.5",
     "fs": "^0.0.1-security",
+    "istextorbinary": "^9.5.0",
     "lz-string": "^1.5.0",
     "winreg": "^1.2.5"
   }

--- a/package.json
+++ b/package.json
@@ -178,6 +178,19 @@
           "type": "boolean",
           "default": true,
           "description": "Include the Shiny header when creating Shinylive app links."
+        },
+        "shiny.shinylive.host": {
+          "type": "string",
+          "default": "https://shinylive.io",
+          "description": "The default Shinylive host to use when creating Shinylive app links.",
+          "enum": [
+            "https://shinylive.io",
+            "https://posit-dev.github.io/shinylive"
+          ],
+          "enumDescriptions": [
+            "Uses the latest released version of Shiny in Python or R",
+            "Uses the latest development version of Shiny in Python or R"
+          ]
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         "shiny.r.devmode": {
           "type": "boolean",
           "default": true,
-          "description": "Enable dev mode when running a Shiny for R app by running `shiny::devmode()` before launching the app."
+          "markdownDescription": "Enable dev mode when running a Shiny for R app by running `shiny::devmode()` before launching the app."
         },
         "shiny.shinylive.mode": {
           "type": "string",
@@ -162,6 +162,11 @@
             "ask",
             "app",
             "editor"
+          ],
+          "enumDescriptions": [
+            "Ask which mode to use.",
+            "App mode displays only the app with an optional header.",
+            "Editor mode displays the app alongside an editor and console."
           ]
         },
         "shiny.shinylive.action": {
@@ -172,12 +177,17 @@
             "ask",
             "open",
             "copy"
+          ],
+          "enumDescriptions": [
+            "Ask which action to take.",
+            "Open the link in the default browser.",
+            "Copy the link to the clipboard."
           ]
         },
         "shiny.shinylive.includeHeader": {
           "type": "boolean",
           "default": true,
-          "description": "Include the Shiny header when creating Shinylive app links."
+          "description": "Include the Shiny header when creating Shinylive app links. Only relevant for app mode Shinylive links."
         },
         "shiny.shinylive.host": {
           "type": "string",
@@ -188,8 +198,8 @@
             "https://posit-dev.github.io/shinylive"
           ],
           "enumDescriptions": [
-            "Uses the latest released version of Shiny in Python or R",
-            "Uses the latest development version of Shiny in Python or R"
+            "Uses the latest released version of Shiny in Python or R.",
+            "Uses the latest development version of Shiny in Python or R."
           ]
         }
       }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,14 @@
       "explorer/context": [
         {
           "command": "shiny.shinylive.createFromExplorer",
-          "group": "shinylive"
+          "group": "shinylive",
+          "when": "true"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "shiny.shinylive.createFromExplorer",
+          "when": "false"
         }
       ],
       "editor/title/run": [

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
       },
       {
         "category": "Shiny",
-        "command": "shiny.shinylive.createFromActiveFile",
-        "title": "Create ShinyLive Link from Active File",
+        "command": "shiny.shinylive.createFromActiveEditor",
+        "title": "Create ShinyLive Link from Active Editor",
         "icon": "$(cloud-upload)",
         "enablement": "editorLangId == python || editorLangId == r"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { pyRunApp, rRunApp, pyDebugApp, onDidStartDebugSession } from "./run";
 import {
   shinyliveCreateFromActiveFile,
   shinyliveSaveAppFromUrl,
+  shinyliveCreateFromExplorer,
 } from "./shinylive";
 
 export function activate(context: vscode.ExtensionContext) {
@@ -18,6 +19,10 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "shiny.shinylive.saveAppFromUrl",
       shinyliveSaveAppFromUrl
+    ),
+    vscode.commands.registerCommand(
+      "shiny.shinylive.createFromExplorer",
+      shinyliveCreateFromExplorer
     )
   );
 
@@ -131,7 +136,10 @@ class Throttler {
   }
 }
 
-function isShinyAppUsername(filename: string, language: string): boolean {
+export function isShinyAppUsername(
+  filename: string,
+  language: string
+): boolean {
   filename = path.basename(filename);
 
   const extension = { python: "py", r: "R" }[language];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,17 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { pyRunApp, rRunApp, pyDebugApp, onDidStartDebugSession } from "./run";
+import { shinyliveCreateFromActiveFile } from "./shinylive";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("shiny.python.runApp", pyRunApp),
     vscode.commands.registerCommand("shiny.python.debugApp", pyDebugApp),
-    vscode.commands.registerCommand("shiny.r.runApp", rRunApp)
+    vscode.commands.registerCommand("shiny.r.runApp", rRunApp),
+    vscode.commands.registerCommand(
+      "shiny.shinylive.createFromActiveFile",
+      shinyliveCreateFromActiveFile
+    )
   );
 
   const throttledUpdateContext = new Throttler(2000, () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { pyRunApp, rRunApp, pyDebugApp, onDidStartDebugSession } from "./run";
 import {
-  shinyliveCreateFromActiveFile,
+  shinyliveCreateFromActiveEditor,
   shinyliveSaveAppFromUrl,
   shinyliveCreateFromExplorer,
 } from "./shinylive";
@@ -13,8 +13,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("shiny.python.debugApp", pyDebugApp),
     vscode.commands.registerCommand("shiny.r.runApp", rRunApp),
     vscode.commands.registerCommand(
-      "shiny.shinylive.createFromActiveFile",
-      shinyliveCreateFromActiveFile
+      "shiny.shinylive.createFromActiveEditor",
+      shinyliveCreateFromActiveEditor
     ),
     vscode.commands.registerCommand(
       "shiny.shinylive.saveAppFromUrl",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,10 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { pyRunApp, rRunApp, pyDebugApp, onDidStartDebugSession } from "./run";
-import { shinyliveCreateFromActiveFile } from "./shinylive";
+import {
+  shinyliveCreateFromActiveFile,
+  shinyliveSaveAppFromUrl,
+} from "./shinylive";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -11,6 +14,10 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "shiny.shinylive.createFromActiveFile",
       shinyliveCreateFromActiveFile
+    ),
+    vscode.commands.registerCommand(
+      "shiny.shinylive.saveAppFromUrl",
+      shinyliveSaveAppFromUrl
     )
   );
 

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -66,7 +66,7 @@ export async function shinyliveCreateFromActiveFile(): Promise<void> {
     },
   ];
 
-  await createAndOpenShinyliveApp(
+  await createAndOpenShinyliveLink(
     files,
     extension.toLowerCase() as ShinyliveLanguage
   );
@@ -82,7 +82,7 @@ export async function shinyliveCreateFromActiveFile(): Promise<void> {
  * to `"py"`.
  * @returns {string} The Shinylive URL, or undefined if the user cancelled.
  */
-async function createAndOpenShinyliveApp(
+async function createAndOpenShinyliveLink(
   files: ShinyliveFile[],
   language: ShinyliveLanguage = "py"
 ): Promise<string | void> {
@@ -289,7 +289,7 @@ export async function shinyliveCreateFromExplorer(
     })
   );
 
-  await createAndOpenShinyliveApp(files, isPythonApp ? "py" : "r");
+  await createAndOpenShinyliveLink(files, isPythonApp ? "py" : "r");
 }
 
 /**

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -122,7 +122,7 @@ export async function shinyliveSaveAppFromUrl(): Promise<void> {
 }
 
 export async function shinyliveCreateFromExplorer(
-  currentFile: vscode.Uri,
+  _activatedFile: vscode.Uri,
   selectedFiles: vscode.Uri[]
 ): Promise<void> {
   const allFiles: vscode.Uri[] = [];

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as lzstring from "lz-string";
 import * as path from "path";
+import * as fs from "fs";
 
 type ShinyliveFile = {
   name: string;
@@ -8,11 +9,15 @@ type ShinyliveFile = {
   type: "text" | "binary";
 };
 
-type ShinyliveBundle = ShinyliveFile[];
-
 type UserOpenAction = "open" | "copy";
 type ShinyliveMode = "app" | "editor";
 type ShinyliveLanguage = "r" | "py";
+
+type ShinyliveBundle = {
+  language: ShinyliveLanguage;
+  files: ShinyliveFile[];
+  mode: ShinyliveMode;
+};
 
 export async function shinyliveCreateFromActiveFile(): Promise<void> {
   if (!vscode.window.activeTextEditor) {
@@ -42,7 +47,7 @@ export async function shinyliveCreateFromActiveFile(): Promise<void> {
 
   const extension = language === "r" ? "R" : "py";
 
-  const bundle: ShinyliveBundle = [
+  const files: ShinyliveFile[] = [
     {
       name: `app.${extension}`,
       content,
@@ -51,11 +56,11 @@ export async function shinyliveCreateFromActiveFile(): Promise<void> {
   ];
 
   const mode = await askUserForMode();
-  const url = shinyliveUrlEncode(
-    bundle,
+  const url = shinyliveUrlEncode({
+    language: extension.toLowerCase() as ShinyliveLanguage,
+    files,
     mode,
-    extension.toLowerCase() as ShinyliveLanguage
-  );
+  });
 
   const action = await askUserForOpenAction();
 
@@ -65,6 +70,43 @@ export async function shinyliveCreateFromActiveFile(): Promise<void> {
     await vscode.env.clipboard.writeText(url);
     vscode.window.showInformationMessage("Copied shinylive link to clipboard!");
   }
+}
+
+export async function shinyliveSaveAppFromUrl(): Promise<void> {
+  const url = await askUserForUrl();
+  if (!url) {
+    return;
+  }
+
+  const bundle = shinyliveUrlDecode(url);
+
+  if (!bundle) {
+    vscode.window.showErrorMessage("Failed to parse the Shinylive link.");
+    return;
+  }
+
+  const { files, language } = bundle;
+
+  if (files.length < 1) {
+    vscode.window.showErrorMessage(
+      "The Shinylive link did not contain any files."
+    );
+    return;
+  }
+
+  const outputDir = await askUserForDir();
+  if (!outputDir) {
+    vscode.window.showErrorMessage("Canceled: no directory selected.");
+    return;
+  }
+
+  const localFiles = await shinyliveWriteFiles(files, outputDir);
+
+  const doc = await vscode.workspace.openTextDocument(
+    vscode.Uri.file(localFiles[0])
+  );
+
+  await vscode.window.showTextDocument(doc, 2, false);
 }
 
 async function askUserForOpenAction(): Promise<UserOpenAction> {
@@ -102,13 +144,39 @@ async function askUserForMode(): Promise<ShinyliveMode> {
   return (mode || "editor") as ShinyliveMode;
 }
 
-function shinyliveUrlEncode(
-  bundle: ShinyliveBundle,
-  mode: ShinyliveMode = "editor",
-  language: ShinyliveLanguage = "py"
-) {
-  const bundleJson = JSON.stringify(bundle);
-  const bundleLZ = lzstring.compressToEncodedURIComponent(bundleJson);
+async function askUserForUrl(): Promise<string> {
+  const url = await vscode.window.showInputBox({
+    title: "Enter or paste a Shinylive link",
+  });
+
+  return url || "";
+}
+
+let lastUsedDir = "";
+
+async function askUserForDir(): Promise<vscode.Uri | undefined> {
+  const defaultDir =
+    lastUsedDir || vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+
+  const uri = await vscode.window.showSaveDialog({
+    defaultUri: vscode.Uri.file(defaultDir || "."),
+    saveLabel: "App directory",
+    title: "Choose a directory where Shinylive app will be saved",
+  });
+
+  if (uri) {
+    // create directory based on uri
+    await vscode.workspace.fs.createDirectory(uri);
+    lastUsedDir = path.dirname(uri.path);
+    return uri;
+  }
+
+  return;
+}
+
+function shinyliveUrlEncode({ language, files, mode }: ShinyliveBundle) {
+  const filesJson = JSON.stringify(files);
+  const filesLZ = lzstring.compressToEncodedURIComponent(filesJson);
 
   if (mode === "app") {
     const includeHeader = vscode.workspace
@@ -117,8 +185,65 @@ function shinyliveUrlEncode(
 
     const h = includeHeader ? "" : "h=0&";
 
-    return `https://shinylive.io/${language}/${mode}/#${h}code=${bundleLZ}`;
+    return `https://shinylive.io/${language}/${mode}/#${h}code=${filesLZ}`;
   }
 
-  return `https://shinylive.io/${language}/${mode}/#code=${bundleLZ}`;
+  return `https://shinylive.io/${language}/${mode}/#code=${filesLZ}`;
+}
+
+function shinyliveUrlDecode(url: string): ShinyliveBundle | undefined {
+  const { hash, pathname } = new URL(url);
+  const { searchParams } = new URL(
+    "https://shinylive.io/?" + hash.substring(1)
+  );
+
+  const code = searchParams.get("code");
+
+  if (!code) {
+    return;
+  }
+
+  const filesJson = lzstring.decompressFromEncodedURIComponent(code);
+  const files = JSON.parse(filesJson);
+
+  const pathParts = pathname.split("/");
+
+  return {
+    language: pathParts[1] as ShinyliveLanguage,
+    files: files as ShinyliveFile[],
+    mode: pathParts[2] as ShinyliveMode,
+  };
+}
+
+async function shinyliveWriteFiles(
+  files: ShinyliveFile[],
+  outputDir: vscode.Uri
+): Promise<string[]> {
+  const localFiles = [];
+
+  for (const file of files) {
+    const filePath = vscode.Uri.file(`${outputDir.fsPath}/${file.name}`);
+    const fileDir = vscode.Uri.file(path.dirname(filePath.fsPath));
+
+    if (!fs.existsSync(fileDir.fsPath)) {
+      await vscode.workspace.fs.createDirectory(fileDir);
+    }
+
+    let contentBuffer: Buffer;
+
+    switch (file.type) {
+      case "binary":
+        contentBuffer = Buffer.from(file.content, "base64");
+        break;
+      default:
+        contentBuffer = Buffer.from(file.content);
+        break;
+    }
+
+    await vscode.workspace.fs.writeFile(filePath, contentBuffer);
+
+    localFiles.push(filePath.path);
+  }
+
+  return localFiles;
 }

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import * as lzstring from "lz-string";
 import * as path from "path";
-import * as fs from "fs";
 import { isBinary } from "istextorbinary";
 import { isShinyAppUsername } from "./extension";
 

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -86,7 +86,7 @@ async function createAndOpenShinyliveApp(
   files: ShinyliveFile[],
   language: ShinyliveLanguage = "py"
 ): Promise<string> {
-  const mode = await askUserForMode();
+  const mode = await askUserForAppMode();
   const url = shinyliveUrlEncode({
     language,
     files,
@@ -300,7 +300,7 @@ async function askUserForOpenAction(): Promise<UserOpenAction> {
   const prefAction =
     vscode.workspace
       .getConfiguration("shiny.shinylive")
-      .get<string>("action") || "ask";
+      .get<string>("openAction") || "ask";
 
   if (["open", "copy"].includes(prefAction)) {
     return prefAction as UserOpenAction;
@@ -320,11 +320,12 @@ async function askUserForOpenAction(): Promise<UserOpenAction> {
  * @async
  * @returns {Promise<ShinyliveMode>} One of `"app"` or `"editor"`.
  */
-async function askUserForMode(): Promise<ShinyliveMode> {
+async function askUserForAppMode(): Promise<ShinyliveMode> {
   // first check if the user has set a default mode
   const prefMode =
-    vscode.workspace.getConfiguration("shiny.shinylive").get<string>("mode") ||
-    "ask";
+    vscode.workspace
+      .getConfiguration("shiny.shinylive")
+      .get<string>("appMode") || "ask";
 
   if (["app", "editor"].includes(prefMode)) {
     return prefMode as ShinyliveMode;

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -30,7 +30,7 @@ type ShinyliveBundle = {
  * @export
  * @async
  */
-export async function shinyliveCreateFromActiveFile(): Promise<void> {
+export async function shinyliveCreateFromActiveEditor(): Promise<void> {
   if (!vscode.window.activeTextEditor) {
     vscode.window.showErrorMessage("No active file");
     return;

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -32,7 +32,7 @@ type ShinyliveBundle = {
  */
 export async function shinyliveCreateFromActiveEditor(): Promise<void> {
   if (!vscode.window.activeTextEditor) {
-    vscode.window.showErrorMessage("No active file");
+    vscode.window.showErrorMessage("Shinylive: no editor is currently active.");
     return;
   }
 
@@ -55,7 +55,7 @@ export async function shinyliveCreateFromActiveEditor(): Promise<void> {
 
     if (!/(^app|app$)/i.test(fileName)) {
       vscode.window.showErrorMessage(
-        "A single-file Shiny app is required when sending the current file to Shinylive."
+        "Shinylive: A single-file Shiny app is required when creating a link from the active editor."
       );
       return;
     }
@@ -136,7 +136,10 @@ export async function shinyliveSaveAppFromUrl(): Promise<void> {
   const bundle = shinyliveUrlDecode(url);
 
   if (!bundle) {
-    vscode.window.showErrorMessage("Failed to parse the Shinylive link.");
+    vscode.window.showErrorMessage(
+      "Shinylive: Failed to parse the Shinylive link. " +
+        "Please check the link and try again."
+    );
     return;
   }
 
@@ -144,7 +147,7 @@ export async function shinyliveSaveAppFromUrl(): Promise<void> {
 
   if (files.length < 1) {
     vscode.window.showErrorMessage(
-      "The Shinylive link did not contain any files."
+      "Shinylive: The provided link did not contain any files."
     );
     return;
   }
@@ -187,7 +190,7 @@ function filesAreNotSingleDir(files: ShinyliveFile[]): boolean {
 
   if (bad.length) {
     vscode.window.showErrorMessage(
-      "The Shinylive link includes files that cannot be written into a " +
+      "Shinylive link includes files that cannot be written into a " +
         "single, contained directory, e.g. '" +
         bad[0] +
         "'. " +
@@ -250,7 +253,7 @@ export async function shinyliveCreateFromExplorer(
 
   if (!isPythonApp && !isRApp) {
     vscode.window.showErrorMessage(
-      "The selected files did not contain a Shiny for Python or R app."
+      "Shinylive: the selected files did not contain a Shiny for Python or R app."
     );
     return;
   }

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -393,17 +393,20 @@ function shinyliveUrlEncode({ language, files, mode }: ShinyliveBundle) {
   const filesJson = JSON.stringify(files);
   const filesLZ = lzstring.compressToEncodedURIComponent(filesJson);
 
+  const host = vscode.workspace
+    .getConfiguration("shiny.shinylive")
+    .get<string>("host");
+
+  let includeHeader;
   if (mode === "app") {
-    const includeHeader = vscode.workspace
+    // Header is only relevant in the `app` mode
+    includeHeader = vscode.workspace
       .getConfiguration("shiny.shinylive")
       .get<boolean>("includeHeader");
-
-    const h = includeHeader ? "" : "h=0&";
-
-    return `https://shinylive.io/${language}/${mode}/#${h}code=${filesLZ}`;
   }
+  const h = includeHeader ? "" : "h=0&";
 
-  return `https://shinylive.io/${language}/${mode}/#code=${filesLZ}`;
+  return `${host}/${language}/${mode}/#${h}code=${filesLZ}`;
 }
 
 /**

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -1,0 +1,124 @@
+import * as vscode from "vscode";
+import * as lzstring from "lz-string";
+import * as path from "path";
+
+type ShinyliveFile = {
+  name: string;
+  content: string;
+  type: "text" | "binary";
+};
+
+type ShinyliveBundle = ShinyliveFile[];
+
+type UserOpenAction = "open" | "copy";
+type ShinyliveMode = "app" | "editor";
+type ShinyliveLanguage = "r" | "py";
+
+export async function shinyliveCreateFromActiveFile(): Promise<void> {
+  if (!vscode.window.activeTextEditor) {
+    vscode.window.showErrorMessage("No active file");
+    return;
+  }
+
+  const content = vscode.window.activeTextEditor.document.getText();
+  const { fileName: filePath, languageId: language } =
+    vscode.window.activeTextEditor.document;
+
+  if (!language || !["r", "python"].includes(language)) {
+    vscode.window.showErrorMessage(
+      "Shinylive only supports Python and R apps."
+    );
+    return;
+  }
+
+  const { name: fileName } = path.parse(filePath);
+
+  if (!/(^app|app$)/i.test(fileName)) {
+    vscode.window.showErrorMessage(
+      "A single-file Shiny app is required when sending the current file to Shinylive."
+    );
+    return;
+  }
+
+  const extension = language === "r" ? "R" : "py";
+
+  const bundle: ShinyliveBundle = [
+    {
+      name: `app.${extension}`,
+      content,
+      type: "text",
+    },
+  ];
+
+  const mode = await askUserForMode();
+  const url = shinyliveUrlEncode(
+    bundle,
+    mode,
+    extension.toLowerCase() as ShinyliveLanguage
+  );
+
+  const action = await askUserForOpenAction();
+
+  if (action === "open") {
+    vscode.env.openExternal(vscode.Uri.parse(url));
+  } else {
+    await vscode.env.clipboard.writeText(url);
+    vscode.window.showInformationMessage("Copied shinylive link to clipboard!");
+  }
+}
+
+async function askUserForOpenAction(): Promise<UserOpenAction> {
+  // first check if the user has set a default action
+  const prefAction =
+    vscode.workspace
+      .getConfiguration("shiny.shinylive")
+      .get<string>("action") || "ask";
+
+  if (["open", "copy"].includes(prefAction)) {
+    return prefAction as UserOpenAction;
+  }
+
+  const action = await vscode.window.showQuickPick(["open", "copy"], {
+    title: "Open or copy the ShinyLive link?",
+  });
+  return (action || "open") as UserOpenAction;
+}
+
+async function askUserForMode(): Promise<ShinyliveMode> {
+  // first check if the user has set a default mode
+  const prefMode =
+    vscode.workspace.getConfiguration("shiny.shinylive").get<string>("mode") ||
+    "ask";
+
+  if (["app", "editor"].includes(prefMode)) {
+    return prefMode as ShinyliveMode;
+  }
+
+  // ask the user if they want to run the app or edit the code
+  const mode = await vscode.window.showQuickPick(["app", "editor"], {
+    title: "Which shinylive mode?",
+  });
+
+  return (mode || "editor") as ShinyliveMode;
+}
+
+function shinyliveUrlEncode(
+  bundle: ShinyliveBundle,
+  mode: ShinyliveMode = "editor",
+  language: ShinyliveLanguage = "py"
+) {
+  const bundleJson = JSON.stringify(bundle);
+  const bundleLZ = lzstring.compressToEncodedURIComponent(bundleJson);
+
+  if (mode === "app") {
+    const includeHeader = vscode.workspace
+      .getConfiguration("shiny.shinylive")
+      .get<boolean>("includeHeader");
+
+    const h = includeHeader ? "" : "h=0&";
+
+    return `https://shinylive.io/${language}/${mode}/#${h}code=${bundleLZ}`;
+  }
+
+  return `https://shinylive.io/${language}/${mode}/#code=${bundleLZ}`;
+}

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -158,7 +158,6 @@ export async function shinyliveSaveAppFromUrl(): Promise<void> {
   );
 
   if (!outputDir) {
-    vscode.window.showErrorMessage("Canceled: no location selected.");
     return;
   }
 
@@ -459,6 +458,7 @@ async function askUserForOutputLocation(
     // get stuck in the "local" directory picker on remote vscode instances
     lastUsedDir =
       vscode.workspace.workspaceFolders?.[0].uri || vscode.Uri.file(".");
+
     return;
   }
 

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -192,6 +192,7 @@ export async function shinyliveCreateFromExplorer(
           return { name, content, type };
 
         default:
+          // Save some characters by relying on the implicit type "text" default
           return { name, content };
       }
     })

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -22,9 +22,9 @@ type ShinyliveBundle = {
 };
 
 /**
- * Command: Create a Shinylive app from the active file in the editor.
+ * Command: Create a Shinylive link from the active editor.
  *
- * The active file must be a single-file Shiny app in Python or R, named
+ * The active editor must be a single-file Shiny app in Python or R, named
  * `app.py` or `app.R` (or similar).
  *
  * @export
@@ -113,7 +113,7 @@ async function createAndOpenShinyliveLink(
 }
 
 /**
- * Command: Save a Shinylive app from a Shinylive link.
+ * Command: Save a Shiny app from a Shinylive link.
  *
  * This command asks the user for a Shinylive link and a directory where the
  * files will be saved. The link is decoded and the files are saved into the
@@ -198,7 +198,7 @@ function filesAreNotSingleDir(files: ShinyliveFile[]): boolean {
 }
 
 /**
- * Command: Save a Shinylive app from the Explorer context menu.
+ * Command: Create a Shinylive link from the Explorer context menu.
  *
  * This command creates a Shinylive app link from the selected files or
  * directories in the Explorer. Directories whose names start with `_` or `.`

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -37,8 +37,11 @@ export async function shinyliveCreateFromActiveEditor(): Promise<void> {
   }
 
   const content = vscode.window.activeTextEditor.document.getText();
-  const { fileName: filePath, languageId: language } =
-    vscode.window.activeTextEditor.document;
+  const {
+    fileName: filePath,
+    languageId: language,
+    isUntitled,
+  } = vscode.window.activeTextEditor.document;
 
   if (!language || !["r", "python"].includes(language)) {
     vscode.window.showErrorMessage(
@@ -47,13 +50,15 @@ export async function shinyliveCreateFromActiveEditor(): Promise<void> {
     return;
   }
 
-  const { name: fileName } = path.parse(filePath);
+  if (!isUntitled) {
+    const { name: fileName } = path.parse(filePath);
 
-  if (!/(^app|app$)/i.test(fileName)) {
-    vscode.window.showErrorMessage(
-      "A single-file Shiny app is required when sending the current file to Shinylive."
-    );
-    return;
+    if (!/(^app|app$)/i.test(fileName)) {
+      vscode.window.showErrorMessage(
+        "A single-file Shiny app is required when sending the current file to Shinylive."
+      );
+      return;
+    }
   }
 
   const extension = language === "r" ? "R" : "py";

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -80,13 +80,17 @@ export async function shinyliveCreateFromActiveFile(): Promise<void> {
  * as `ShinyliveFile` objects.
  * @param {ShinyliveLanguage} [language="py"] One of `"py"` or `"r"`, defaults
  * to `"py"`.
- * @returns {string} The Shinylive URL.
+ * @returns {string} The Shinylive URL, or undefined if the user cancelled.
  */
 async function createAndOpenShinyliveApp(
   files: ShinyliveFile[],
   language: ShinyliveLanguage = "py"
-): Promise<string> {
+): Promise<string | void> {
   const mode = await askUserForAppMode();
+  if (!mode) {
+    return;
+  }
+
   const url = shinyliveUrlEncode({
     language,
     files,
@@ -94,6 +98,9 @@ async function createAndOpenShinyliveApp(
   });
 
   const action = await askUserForOpenAction();
+  if (!action) {
+    return;
+  }
 
   if (action === "open") {
     vscode.env.openExternal(vscode.Uri.parse(url));
@@ -302,9 +309,10 @@ async function readDirectoryRecursively(
  * settings to avoid the prompt.
  *
  * @async
- * @returns {Promise<UserOpenAction>} One of `"open"` or `"copy"`.
+ * @returns {Promise<UserOpenAction>} One of `"open"` or `"copy"`, or an empty
+ * string if the user cancelled.
  */
-async function askUserForOpenAction(): Promise<UserOpenAction> {
+async function askUserForOpenAction(): Promise<UserOpenAction | ""> {
   // first check if the user has set a default action
   const prefAction =
     vscode.workspace
@@ -318,7 +326,8 @@ async function askUserForOpenAction(): Promise<UserOpenAction> {
   const action = await vscode.window.showQuickPick(["open", "copy"], {
     title: "Open or copy the ShinyLive link?",
   });
-  return (action || "open") as UserOpenAction;
+
+  return action ? (action as UserOpenAction) : "";
 }
 
 /**
@@ -327,9 +336,10 @@ async function askUserForOpenAction(): Promise<UserOpenAction> {
  * their settings to avoid the prompt.
  *
  * @async
- * @returns {Promise<ShinyliveMode>} One of `"app"` or `"editor"`.
+ * @returns {Promise<ShinyliveMode>} One of `"app"` or `"editor"`, or an empty
+ * string if the user cancelled.
  */
-async function askUserForAppMode(): Promise<ShinyliveMode> {
+async function askUserForAppMode(): Promise<ShinyliveMode | ""> {
   // first check if the user has set a default mode
   const prefMode =
     vscode.workspace
@@ -345,7 +355,7 @@ async function askUserForAppMode(): Promise<ShinyliveMode> {
     title: "Which shinylive mode?",
   });
 
-  return (mode || "editor") as ShinyliveMode;
+  return mode ? (mode as ShinyliveMode) : "";
 }
 
 /**

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -350,12 +350,22 @@ async function askUserForAppMode(): Promise<ShinyliveMode | ""> {
     return prefMode as ShinyliveMode;
   }
 
-  // ask the user if they want to run the app or edit the code
-  const mode = await vscode.window.showQuickPick(["app", "editor"], {
-    title: "Which shinylive mode?",
+  const options: vscode.QuickPickItem[] = [
+    {
+      label: "app",
+      detail: "App mode displays only the app on Shinylive.",
+    },
+    {
+      label: "editor",
+      detail: "Editor mode displays the app alongside an editor and console.",
+    },
+  ];
+
+  const mode = await vscode.window.showQuickPick(options, {
+    title: "Which Shinylive mode?",
   });
 
-  return mode ? (mode as ShinyliveMode) : "";
+  return mode ? (mode.label as ShinyliveMode) : "";
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,6 +971,11 @@ lru-cache@^6.0.0:
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz"
   integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,6 +334,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+binaryextensions@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-6.11.0.tgz#c36b3e6b5c59e621605709b099cda8dda824cc72"
+  integrity sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==
+  dependencies:
+    editions "^6.21.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
@@ -474,6 +481,13 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+editions@^6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-6.21.0.tgz#8da2d85611106e0891a72619b7bee8e0c830089b"
+  integrity sha512-ofkXJtn7z0urokN62DI3SBo/5xAtF0rR7tn+S/bSYV79Ka8pTajIIl+fFQ1q88DQEImymmo97M4azY3WX/nUdg==
+  dependencies:
+    version-range "^4.13.0"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -875,6 +889,15 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+istextorbinary@^9.5.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-9.5.0.tgz#e6e13febf1c1685100ae264809a4f8f46e01dfd3"
+  integrity sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==
+  dependencies:
+    binaryextensions "^6.11.0"
+    editions "^6.21.0"
+    textextensions "^6.11.0"
 
 jackspeak@^2.3.5:
   version "2.3.6"
@@ -1340,6 +1363,13 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+textextensions@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-6.11.0.tgz#864535d09f49026150c96f0b0d79f1fa0869db15"
+  integrity sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==
+  dependencies:
+    editions "^6.21.0"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
@@ -1385,6 +1415,11 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+version-range@^4.13.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/version-range/-/version-range-4.14.0.tgz#91c12e4665756a9101d1af43faeda399abe0edec"
+  integrity sha512-gjb0ARm9qlcBAonU4zPwkl9ecKkas+tC2CGwFfptTCWWIVTWY1YUbT2zZKsOAF1jR/tNxxyLwwG0cb42XlYcTg==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
This PR adds support for creating and saving Shinylive apps to the vscode extension with three commands:

1. **Create ShinyLive Link from Active File**. Sends the currently open single-file app to Shinylive, e.g. good for simple, single-file `app.py` or `app.R` examples.

2. **Create Shinylive Link from Selected Files**. In the file explorer tree, when right clicking on a file, a directory or a selection of multiple files/directories, users can select this command to send the selection to Shinylive.

3. **Save App from Shinylive Link**. Paste a [shinylive.io](https://shinylive.io) link and choose a directory or path where the app in the link should be saved. 
	* If the Shinylive link points to a **single-file app**, users can pick a file location for the app, which may also overwrite an existing app. 
	* If the Shinylive link points to a **multi-file app**, the user is asked to pick a non-existent directory and the directory is created and the files encoded in the link are saved there. After saving, the first file in the bundle is opened in the editor. 

**TODO**

- [x] Update README