### PR TITLE
ci: Bump to latest v4 actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
       - run: yarn install --immutable --immutable-cache --check-cache
@@ -23,7 +23,7 @@ jobs:
         run: yarn vsix
 
       - name: Upload extension to Actions Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: shiny-vscode
           path: "shiny*.vsix"


### PR DESCRIPTION
Uses `actions/checkout@v4`, `actions/setup-node@v4` and `actions/upload-artifact@v4` to avoid warnings about deprecated node versions.