### PR TITLE
Fix escaping for `cmd.exe`: either quote or escape individual special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The [Python VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) is now a soft dependency and is no longer installed by default with the Shiny for VS Code extension. (#30)
 - Added a new setting, `shiny.previewType`, to control where the Shiny app preview should be opened. (#40)
 - Added a new `shinyexpress` snippet to quickly create a basic Shiny Express app in Python. (#42)
+- Fixed a bug that would doubly-escape paths with spaces when launching Shiny apps on Windows via `cmd.exe`. ([#46](https://github.com/posit-dev/shiny-vscode/issues/46))
 
 ## 0.1.6
 

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -33,8 +33,9 @@ export function escapeArg(arg: string, style: EscapeStyle): string {
   switch (style) {
     case "cmd":
       // For cmd.exe, double quotes are used to handle spaces, and carets (^) are used to escape special characters.
-      const escaped = arg.replace(/([()%!^"<>&|])/g, "^$1");
-      return /\s/.test(escaped) ? `"${escaped}"` : escaped;
+      return /\s/.test(arg)
+        ? `"${arg}"`
+        : arg.replace(/([()%!^"<>&|])/g, "^$1");
 
     case "ps":
       if (!/[ '"`,;(){}|&<>@#[\]]/.test(arg)) {

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -32,10 +32,17 @@ function escapeStyle(terminal: vscode.Terminal): EscapeStyle {
 export function escapeArg(arg: string, style: EscapeStyle): string {
   switch (style) {
     case "cmd":
-      // For cmd.exe, double quotes are used to handle spaces, and carets (^) are used to escape special characters.
-      return /\s/.test(arg)
-        ? `"${arg}"`
-        : arg.replace(/([()%!^"<>&|])/g, "^$1");
+      // For cmd.exe, use double quotes if input includes spaces
+      if (/\s/.test(arg)) {
+        if (!arg.includes('"')) {
+          return `"${arg}"`;
+        }
+        // Escape double quotes by doubling them
+        return `"${arg.replace(/"/g, '"""')}"`;
+      }
+
+      // Carets (^) are used to escape special characters in unquoted strings.
+      return arg.replace(/([()%!^"<>&|])/g, "^$1");
 
     case "ps":
       if (!/[ '"`,;(){}|&<>@#[\]]/.test(arg)) {


### PR DESCRIPTION
Fixes #46 

Prior to this PR, for `cmd.exe` commands, we would escape special characters and then, if the escaped string contains a space we'd wrap the string in `" "`.

For a string like `C:\Program Files (x86)\R\R-4.3.3\bin\Rscript.exe`, we'd turn `(` and `)` into `^(` and `^)`, but we'd then also wrap the string in `""` resulting in 

```
"C:\Program Files ^(x86^)\R\R-4.3.3\bin\Rscript.exe"
```

This would break because the `""` handles the escaping of the parenthesis. This PR changes the escaping to either escape individual special characters or wrap the string in `""` if it contains a space.