### PR TITLE
fix: Don't open blank page in external browser

### DIFF
--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -72,6 +72,10 @@ export async function openBrowser(url: string): Promise<void> {
     case "none":
       return;
     case "external": {
+      if (url === "about:blank") {
+        // don't need to open a blank page in external browser
+        return;
+      }
       vscode.env.openExternal(vscode.Uri.parse(url));
       return;
     }


### PR DESCRIPTION
We pre-load `about:blank` internally to clear the internal browser or signal that we're working on opening the Shiny app, but for external previews this step is unnecessary.