### PR TITLE
Rename extension - Part 1 - New name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "shiny-python",
+  "name": "shiny",
   "displayName": "Shiny",
   "description": "Run and develop Shiny apps in Python or R.",
-  "version": "0.2.1-dev",
+  "version": "1.0.0-rc1",
   "publisher": "Posit",
   "icon": "logo.png",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
   "activationEvents": [
     "onStartupFinished",
     "onLanguage:python",
-    "onCommand:shiny.python.runApp",
-    "onCommand:shiny.python.debugApp",
-    "onLanguage:r",
-    "onCommand:shiny.r.runApp"
+    "onLanguage:r"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shiny",
   "displayName": "Shiny",
   "description": "Run and develop Shiny apps in Python or R.",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0",
   "publisher": "Posit",
   "icon": "logo.png",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "Other"
   ],
   "activationEvents": [
-    "onStartupFinished",
     "onLanguage:python",
-    "onLanguage:r"
+    "onCommand:shiny.python.runApp",
+    "onCommand:shiny.python.debugApp",
+    "onLanguage:r",
+    "onCommand:shiny.r.runApp"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "Other"
   ],
   "activationEvents": [
+    "onStartupFinished",
     "onLanguage:python",
     "onCommand:shiny.python.runApp",
     "onCommand:shiny.python.debugApp",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,8 @@ export function isShinyAppRPart(filename: string): boolean {
 }
 
 async function checkForOutdatedShinyExtension(): Promise<boolean> {
-  if (!vscode.extensions.getExtension("Posit.shiny-python")) {
+  const oldExtension = vscode.extensions.getExtension("Posit.shiny-python");
+  if (!oldExtension || !oldExtension.isActive) {
     return false;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,9 +7,7 @@ import {
   shinyliveCreateFromExplorer,
 } from "./shinylive";
 
-export async function activate(context: vscode.ExtensionContext) {
-  await checkForOutdatedShinyExtension();
-
+export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("shiny.python.runApp", pyRunApp),
     vscode.commands.registerCommand("shiny.python.debugApp", pyDebugApp),
@@ -179,32 +177,4 @@ export function isShinyAppUsername(
 export function isShinyAppRPart(filename: string): boolean {
   filename = path.basename(filename);
   return ["ui.r", "server.r", "global.r"].includes(filename.toLowerCase());
-}
-
-async function checkForOutdatedShinyExtension(): Promise<boolean> {
-  const oldExtension = vscode.extensions.getExtension("Posit.shiny-python");
-  if (!oldExtension || !oldExtension.isActive) {
-    return false;
-  }
-
-  const response = await vscode.window.showInformationMessage(
-    "You have both the Shiny and Shiny for Python extension, but the Shiny for Python extension is deprecated. Please disable or uninstall it.",
-    "Uninstall old",
-    "Manually disable"
-  );
-
-  if (response === "Manually disable") {
-    vscode.commands.executeCommand(
-      "workbench.extensions.search",
-      "Posit.shiny-python"
-    );
-    return true;
-  }
-
-  vscode.commands.executeCommand(
-    "workbench.extensions.uninstallExtension",
-    "Posit.shiny-python"
-  );
-
-  return false;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,9 @@ import {
   shinyliveCreateFromExplorer,
 } from "./shinylive";
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
+  await checkForOutdatedShinyExtension();
+
   context.subscriptions.push(
     vscode.commands.registerCommand("shiny.python.runApp", pyRunApp),
     vscode.commands.registerCommand("shiny.python.debugApp", pyDebugApp),
@@ -177,4 +179,31 @@ export function isShinyAppUsername(
 export function isShinyAppRPart(filename: string): boolean {
   filename = path.basename(filename);
   return ["ui.r", "server.r", "global.r"].includes(filename.toLowerCase());
+}
+
+async function checkForOutdatedShinyExtension(): Promise<boolean> {
+  if (!vscode.extensions.getExtension("Posit.shiny-python")) {
+    return false;
+  }
+
+  const response = await vscode.window.showInformationMessage(
+    "You have both the Shiny and Shiny for Python extension, but the Shiny for Python extension is deprecated. Please disable or uninstall it.",
+    "Uninstall old",
+    "Manually disable"
+  );
+
+  if (response === "Manually disable") {
+    vscode.commands.executeCommand(
+      "workbench.extensions.search",
+      "Posit.shiny-python"
+    );
+    return true;
+  }
+
+  vscode.commands.executeCommand(
+    "workbench.extensions.uninstallExtension",
+    "Posit.shiny-python"
+  );
+
+  return false;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -333,7 +333,7 @@ function getActiveEditorFile(): string | undefined {
 
 function getExtensionPath(): string | undefined {
   const extensionPath =
-    vscode.extensions.getExtension("Posit.shiny-python")?.extensionPath;
+    vscode.extensions.getExtension("Posit.shiny")?.extensionPath;
   if (!extensionPath) {
     vscode.window.showErrorMessage(
       "Cannot run Shiny app: failed to locate extension directory"

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -181,7 +181,7 @@ export async function shinyliveSaveAppFromUrl(): Promise<void> {
 
   const doc = await vscode.workspace.openTextDocument(localFiles[0]);
 
-  await vscode.window.showTextDocument(doc, 2, false);
+  await vscode.window.showTextDocument(doc, undefined, false);
 }
 
 function filesAreNotSingleDir(files: ShinyliveFile[]): boolean {

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -542,12 +542,10 @@ function shinyliveUrlDecode(url: string): ShinyliveBundle | undefined {
   });
 
   const pathParts = pathname.split("/");
+  const language: ShinyliveLanguage = pathParts.includes("py") ? "py" : "r";
+  const mode: ShinyliveMode = pathParts.includes("editor") ? "editor" : "app";
 
-  return {
-    language: pathParts[1] as ShinyliveLanguage,
-    files: files as ShinyliveFile[],
-    mode: pathParts[2] as ShinyliveMode,
-  };
+  return { language, mode, files: files as ShinyliveFile[] };
 }
 
 /**


### PR DESCRIPTION
Updates the extension ID to be `Posit.shiny` and moves the extension to `v1.0.0`.

The outdated extension points to this extension as a dependency and uninstalls itself upon activation.

For #53