### PR TITLE
ci: clean up publish actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
+
       - run: yarn install --immutable --immutable-cache --check-cache
 
       - name: Build Extension
@@ -27,7 +28,7 @@ jobs:
         with:
           name: shiny-vscode
           path: "shiny*.vsix"
-          
+
   publish-open-vsx:
     runs-on: ubuntu-latest
     if: ${{
@@ -41,17 +42,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
-      - run: yarn install --immutable --immutable-cache --check-cache
 
-      - name: Build Extension
-        run: yarn vsix
+      - run: yarn install --immutable --immutable-cache --check-cache
 
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
-  
+
   publish-vscode-marketplace:
     runs-on: ubuntu-latest
     if: ${{
@@ -65,11 +64,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
+
       - run: yarn install --immutable --immutable-cache --check-cache
 
-      - name: Build Extension
-        run: yarn vsix
-        
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          skipDuplicate: true
           dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
 
   publish-vscode-marketplace:
@@ -71,5 +72,6 @@ jobs:
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VSCE_PAT }}
+          skipDuplicate: true
           registryUrl: https://marketplace.visualstudio.com
           dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
   publish-open-vsx:
     runs-on: ubuntu-latest
     if: ${{
-      (github.event_name == 'push' && github.repository_owner == 'posit-dev') ||
+      (github.event_name == 'push' && github.ref_type == 'tag' && github.repository_owner == 'posit-dev') ||
       github.event.pull_request.head.repo.fork == false
       }}
     needs:
@@ -50,12 +50,11 @@ jobs:
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           skipDuplicate: true
-          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}
 
   publish-vscode-marketplace:
     runs-on: ubuntu-latest
     if: ${{
-      (github.event_name == 'push' && github.repository_owner == 'posit-dev') ||
+      (github.event_name == 'push' && github.ref_type == 'tag' && github.repository_owner == 'posit-dev') ||
       github.event.pull_request.head.repo.fork == false
       }}
     needs:
@@ -74,4 +73,3 @@ jobs:
           pat: ${{ secrets.VSCE_PAT }}
           skipDuplicate: true
           registryUrl: https://marketplace.visualstudio.com
-          dryRun: ${{ !(github.event_name == 'push' && github.ref_type == 'tag') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,10 +34,10 @@ jobs:
 
   publish-open-vsx:
     runs-on: ubuntu-latest
-    if: ${{
-      (github.event_name == 'push' && github.ref_type == 'tag' && github.repository_owner == 'posit-dev') ||
-      github.event.pull_request.head.repo.fork == false
-      }}
+    if: |
+      github.event_name == 'push' &&
+      github.ref_type == 'tag' &&
+      github.repository_owner == 'posit-dev'
     needs:
       - build-vsix
     steps:
@@ -56,10 +56,10 @@ jobs:
 
   publish-vscode-marketplace:
     runs-on: ubuntu-latest
-    if: ${{
-      (github.event_name == 'push' && github.ref_type == 'tag' && github.repository_owner == 'posit-dev') ||
-      github.event.pull_request.head.repo.fork == false
-      }}
+    if: |
+      github.event_name == 'push' &&
+      github.ref_type == 'tag' &&
+      github.repository_owner == 'posit-dev'
     needs:
       - build-vsix
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
 
       - run: yarn install --immutable --immutable-cache --check-cache
 
+      - name: Lint Extension
+        run: yarn lint
+
       - name: Build Extension
         run: yarn vsix
 


### PR DESCRIPTION
High priority follow up from #53, this finishes up the work in https://github.com/posit-dev/shiny-vscode/commit/c348df2b68dce61dffd3dd75adc232a653363460

* We now only run the publish jobs when we're actually wanting to publish the extension, i.e. on tags pushed to the `posit-dev` owned repo. **Note: this fixes a bug I introduced when working quickly to get the marketplace extension published.**

* Otherwise we lint and build the extension, where building the extension also calls `yarn compile`. This is a superset of what happens when `dryRun: true`, so the extra dry run publishing isn't required.

* The publish jobs fail silently if the extension is already published by setting `skipDuplicate: true` in the `publish-vscode-extension` settings.

All jobs are fast enough that it's not worth the extra effort to download the vsix artifact in the publish jobs.