### PR TITLE
feat: Save active editor before running the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Improved feedback when waiting for a slow Shiny app to start up. ([#65](https://github.com/posit-dev/shiny-vscode/pull/65))
 
+- The "Run Shiny app" command now saves the active file before running the app. ([#68](https://github.com/posit-dev/shiny-vscode/pull/68))
+
 ## 1.0.0
 
 The Shiny extension for VS Code now has a new extension ID: `Posit.shiny`! New Shiny users should install the Shiny extension from [the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=Posit.shiny) or [https://open-vsx.org/extension/posit/shiny](https://open-vsx.org/extension/posit/shiny).

--- a/src/run.ts
+++ b/src/run.ts
@@ -26,6 +26,8 @@ export async function pyRunApp(): Promise<void> {
     return;
   }
 
+  await saveActiveEditorFile();
+
   const python = await getSelectedPythonInterpreter();
   if (!python) {
     return;
@@ -103,6 +105,8 @@ export async function pyDebugApp(): Promise<void> {
     return;
   }
 
+  await saveActiveEditorFile();
+
   const python = await getSelectedPythonInterpreter();
   if (!python) {
     return;
@@ -136,6 +140,8 @@ export async function rRunApp(): Promise<void> {
   if (!pathFile) {
     return;
   }
+
+  await saveActiveEditorFile();
 
   const path = isShinyAppRPart(pathFile) ? path_dirname(pathFile) : pathFile;
 
@@ -330,6 +336,12 @@ function getActiveEditorFile(): string | undefined {
     return;
   }
   return appPath;
+}
+
+async function saveActiveEditorFile(): Promise<void> {
+  if (vscode.window.activeTextEditor?.document.isDirty) {
+    await vscode.window.activeTextEditor?.document.save();
+  }
 }
 
 function getExtensionPath(): string | undefined {


### PR DESCRIPTION
Currently, pressing the "play" button to run an open app will run the app using the file as it is on disk, ignoring any changes in the current editor.

This PR updates the "Run Shiny app" command to save the currently active file if it's dirty, which matches the behavior of the Quarto `.qmd` preview button as well as the "Run Shiny app" experience in RStudio.

If we're worried about this being too presumptive, we could put this behind a configuration setting. But note that this behavior isn't optional in the Quarto extension.