### PR TITLE
feat: Make "simple browser" an explicit preview type option

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,12 +121,14 @@
           "description": "Where should the Shiny app preview open?",
           "enum": [
             "internal",
+            "simple browser",
             "external",
             "none"
           ],
           "default": "internal",
           "enumDescriptions": [
-            "Preview using a side-by-side panel inside VS Code",
+            "Preview using the viewer pane in Positron or the Simple Browser in VS Code",
+            "Preview using the Simple Browser (an internal, basic browser preview)",
             "Preview using an external web browser",
             "Don't automatically launch the app after starting"
           ]


### PR DESCRIPTION
Adds `"simple browser"` as a `shiny.previewType` option and updates the help text to reference Positron.

Technically, this just makes implicit behavior explicit -- any value that isn't `internal`, `external`, or `none` defaults to using the Simple Browser, but you had to modify settings via JSON to take advantage.

I find it useful to differentiate between the viewer pane and a simple browser. For example, while working on a workshop I could use the Viewer pane to preview Quarto slides while also running and editing a Shiny app with its preview in a Simple Browser tab.