### PR TITLE
feat: Support opening shinylive apps locally from a `vscode://` or `positron://` URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Improved feedback when waiting for a slow Shiny app to start up. ([#65](https://github.com/posit-dev/shiny-vscode/pull/65))
 
+- The extension can now open Shinylive apps locally from `vscode://posit.shiny/shinylive?url=...` links. ([#70](https://github.com/posit-dev/shiny-vscode/pull/70))
+
 ## 1.0.0
 
 The Shiny extension for VS Code now has a new extension ID: `Posit.shiny`! New Shiny users should install the Shiny extension from [the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=Posit.shiny) or [https://open-vsx.org/extension/posit/shiny](https://open-vsx.org/extension/posit/shiny).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "onCommand:shiny.python.runApp",
     "onCommand:shiny.python.debugApp",
     "onLanguage:r",
-    "onCommand:shiny.r.runApp"
+    "onCommand:shiny.r.runApp",
+    "onUri"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/extension-onUri.ts
+++ b/src/extension-onUri.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+import { URLSearchParams } from "url";
+import { shinyliveSaveAppFromUrl } from "./shinylive";
+
+export function handlePositShinyUri(uri: vscode.Uri): void {
+  if (!["/shinylive", "/shinylive/"].includes(uri.path)) {
+    console.warn(`[shiny] Unexpected URI: ${uri.toString()}`);
+    return;
+  }
+
+  const encodedUrl = new URLSearchParams(uri.query).get("url");
+
+  if (!encodedUrl) {
+    vscode.window.showErrorMessage(
+      "No URL provided in the Open from Shinylive link."
+    );
+    return;
+  }
+
+  const decodedUrl = decodeURIComponent(encodedUrl);
+  shinyliveSaveAppFromUrl(decodedUrl);
+}

--- a/src/extension-onUri.ts
+++ b/src/extension-onUri.ts
@@ -1,8 +1,12 @@
 import * as vscode from "vscode";
 import { URLSearchParams } from "url";
-import { shinyliveSaveAppFromUrl } from "./shinylive";
+import {
+  shinyliveSaveAppFromUrl,
+  shinyliveUrlDecode,
+  shinyliveUrlEncode,
+} from "./shinylive";
 
-export function handlePositShinyUri(uri: vscode.Uri): void {
+export async function handlePositShinyUri(uri: vscode.Uri): Promise<void> {
   if (!["/shinylive", "/shinylive/"].includes(uri.path)) {
     console.warn(`[shiny] Unexpected URI: ${uri.toString()}`);
     return;
@@ -17,6 +21,62 @@ export function handlePositShinyUri(uri: vscode.Uri): void {
     return;
   }
 
-  const decodedUrl = decodeURIComponent(encodedUrl);
-  shinyliveSaveAppFromUrl(decodedUrl);
+  const url = decodeURIComponent(encodedUrl);
+  const bundle = shinyliveUrlDecode(url);
+
+  if (!bundle) {
+    vscode.window.showErrorMessage(
+      "Shinylive: Failed to parse the Shinylive link. " +
+        "Please check the link and try again."
+    );
+    return;
+  }
+
+  let filesText = bundle.files
+    .slice(0, 3)
+    .map((f) => f.name)
+    .join(", ");
+  if (bundle.files.length > 3) {
+    filesText += `, and ${bundle.files.length - 3} more files`;
+  }
+
+  const reviewAction = await vscode.window.showWarningMessage(
+    `You are about to save a Shinylive app with ${filesText} to your workspace. Would you like to...`,
+    { modal: true },
+    { title: "Cancel", action: "cancel" },
+    { title: "Review the app on shinylive.io", action: "review" },
+    {
+      title: `Save app ${bundle.files.length === 1 ? "file" : "files"} locally`,
+      action: "save",
+    }
+  );
+
+  let { action } = reviewAction || { action: "cancel" };
+
+  if (action === "cancel") {
+    return;
+  }
+
+  if (action === "review") {
+    bundle.mode = "editor";
+    const editorUrl = shinyliveUrlEncode(bundle);
+    vscode.env.openExternal(vscode.Uri.parse(editorUrl));
+
+    const openAfterReview = await vscode.window.showInformationMessage(
+      "After reviewing the Shinylive app, would you like to save it?",
+      { modal: true },
+      "No",
+      "Yes"
+    );
+
+    if (!openAfterReview || openAfterReview === "No") {
+      return;
+    }
+    action = "save";
+  }
+
+  if (action === "save") {
+    await shinyliveSaveAppFromUrl(url);
+    return;
+  }
 }

--- a/src/extension-onUri.ts
+++ b/src/extension-onUri.ts
@@ -65,11 +65,10 @@ export async function handlePositShinyUri(uri: vscode.Uri): Promise<void> {
     const openAfterReview = await vscode.window.showInformationMessage(
       "After reviewing the Shinylive app, would you like to save it?",
       { modal: true },
-      "No",
       "Yes"
     );
 
-    if (!openAfterReview || openAfterReview === "No") {
+    if (!openAfterReview) {
       return;
     }
     action = "save";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
   shinyliveSaveAppFromUrl,
   shinyliveCreateFromExplorer,
 } from "./shinylive";
+import { handlePositShinyUri } from "./extension-onUri";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -23,7 +24,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "shiny.shinylive.createFromExplorer",
       shinyliveCreateFromExplorer
-    )
+    ),
+    vscode.window.registerUriHandler({
+      handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
+        handlePositShinyUri(uri);
+      },
+    })
   );
 
   const throttledUpdateContext = new Throttler(2000, () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -360,7 +360,7 @@ async function getRPathFromPositron(bin: string): Promise<string> {
     return "";
   }
 
-  console.log(`[shiny] runtimeMetadata: ${JSON.stringify(runtimeMetadata)}`)
+  console.log(`[shiny] runtimeMetadata: ${JSON.stringify(runtimeMetadata)}`);
 
   const runtimePath = runtimeMetadata.runtimePath;
   if (!runtimePath) {

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -504,7 +504,7 @@ async function askUserForOutputLocation(
  * with the language, files, and mode to encode.
  * @returns {string} The encoded Shinylive URL.
  */
-function shinyliveUrlEncode({ language, files, mode }: ShinyliveBundle) {
+export function shinyliveUrlEncode({ language, files, mode }: ShinyliveBundle) {
   const filesJson = JSON.stringify(files);
   const filesLZ = lzstring.compressToEncodedURIComponent(filesJson);
 
@@ -531,7 +531,7 @@ function shinyliveUrlEncode({ language, files, mode }: ShinyliveBundle) {
  * @returns {ShinyliveBundle | undefined} The decoded Shinylive bundle, or
  * `undefined` if the URL could not be decoded.
  */
-function shinyliveUrlDecode(url: string): ShinyliveBundle | undefined {
+export function shinyliveUrlDecode(url: string): ShinyliveBundle | undefined {
   const { hash, pathname } = new URL(url);
   const { searchParams } = new URL(
     "https://shinylive.io/?" + hash.substring(1)

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -123,11 +123,19 @@ async function createAndOpenShinyliveLink(
  * files will be saved. The link is decoded and the files are saved into the
  * directory.
  *
+ * @param {string} [url] The Shinylive URL to save the app from. If not provided
+ * the user will be prompted to enter a URL.
+ *
  * @export
  * @async
  */
-export async function shinyliveSaveAppFromUrl(): Promise<void> {
-  const url = await askUserForUrl();
+export async function shinyliveSaveAppFromUrl(
+  url: string | undefined
+): Promise<void> {
+  if (typeof url === "undefined") {
+    url = await askUserForUrl();
+  }
+
   if (!url) {
     return;
   }


### PR DESCRIPTION
Closes #58

Adds support for `positron://`, `vscode://`, `vscode-insiders://`, or `cursor://` links of the form

```
vscode://posit.shiny/shinylive?url={encodeURIComponent(shinylive_url)}
```

Clicking a link like this will open Positron/VS Code/Cursor and prompt the user to choose a location to save the file, building on the existing "Save App from Shinylive Link" command.


https://github.com/user-attachments/assets/8fda83a9-4bf5-4a2d-a1ee-5ca23b0ea1fe


These URLs are easy to construct:

```js
const shinyliveUrl = "https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXGKAHVA6VBPMAaMAYwHsIAXOcpMAMwCdiYACAZwAsBLCbDOAD1R04LFkw4xUxOmTERUAVzJ4mQiABM4dZfI4AdCPp0Y2AJgAUusAAk4AG1vFlAdym21AQksBKQxwxcFMgB9FlsODToLSEtlSwA5GKYABmUARiSUphMknwM8gAFVCIwSDX0NGiYyPjIzL0R9JiaVODJ5OggmGksIACoTMVEQAMUMCDqmXqyAX0t9MGmAXSA"
const url = new URL("positron://Posit.shiny/shinylive/")
url.searchParams.set("url", encodeURIComponent(shinyliveUrl))
url.toString()

// positron://Posit.shiny/shinylive/?url=https%253A%252F%252Fshinylive.io%252Fpy%252Feditor%252F%2523code%253DNobwRAdghgtgpmAXGKAHVA6VBPMAaMAYwHsIAXOcpMAMwCdiYACAZwAsBLCbDOAD1R04LFkw4xUxOmTERUAVzJ4mQiABM4dZfI4AdCPp0Y2AJgAUusAAk4AG1vFlAdym21AQksBKQxwxcFMgB9FlsODToLSEtlSwA5GKYABmUARiSUphMknwM8gAFVCIwSDX0NGiYyPjIzL0R9JiaVODJ5OggmGksIACoTMVEQAMUMCDqmXqyAX0t9MGmAXSA
// vscode://Posit.shiny/shinylive/?url=https%253A%252F%252Fshinylive.io%252Fpy%252Feditor%252F%2523code%253DNobwRAdghgtgpmAXGKAHVA6VBPMAaMAYwHsIAXOcpMAMwCdiYACAZwAsBLCbDOAD1R04LFkw4xUxOmTERUAVzJ4mQiABM4dZfI4AdCPp0Y2AJgAUusAAk4AG1vFlAdym21AQksBKQxwxcFMgB9FlsODToLSEtlSwA5GKYABmUARiSUphMknwM8gAFVCIwSDX0NGiYyPjIzL0R9JiaVODJ5OggmGksIACoTMVEQAMUMCDqmXqyAX0t9MGmAXSA
```