### PR TITLE
refactor: `shinyliveSaveAppFromUrl()`

### DIFF
--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -433,13 +433,13 @@ let lastUsedDir: vscode.Uri;
 
 /**
  * Ask the user for an output location where a single-file Shinylive app will be
- * saved.
+ * saved. VS Code will create non-existent directories and ask the user to
+ * confirm they want to overwrite existing files.
  *
  * @async
- * @param {string} [defaultName] If the app is a single file, the name of the
- * file to save. This will be used as the default file name in the save dialog.
+ * @param {string} [defaultName] The default file name used in the save dialog.
  * @returns {Promise<vscode.Uri | undefined>} A `vscode.Uri` object of the
- * selected directory, or `undefined` if the user canceled the selection.
+ * selected file, or `undefined` if the user canceled the selection.
  */
 async function askUserForOutputFile(
   defaultName: string
@@ -474,7 +474,7 @@ async function askUserForOutputFile(
 
 /**
  * Ask the user for an output directory where a multi-file Shinylive app will be
- * saved. VSCode will force the user to pick a non-existent directory.
+ * saved. VS Code will force the user to pick a non-existent directory.
  *
  * @async
  * @returns {Promise<vscode.Uri | undefined>} A `vscode.Uri` object of the

--- a/src/shinylive.ts
+++ b/src/shinylive.ts
@@ -159,7 +159,7 @@ export async function shinyliveSaveAppFromUrl(
     return;
   }
 
-  if (filesAreNotSingleDir(files)) {
+  if (filesAreNotContainedSingleDir(files)) {
     return;
   }
 
@@ -192,7 +192,7 @@ export async function shinyliveSaveAppFromUrl(
   await vscode.window.showTextDocument(doc, undefined, false);
 }
 
-function filesAreNotSingleDir(files: ShinyliveFile[]): boolean {
+function filesAreNotContainedSingleDir(files: ShinyliveFile[]): boolean {
   const bad = files.map((f) => f.name).filter((nm) => nm.startsWith(".."));
 
   if (bad.length) {


### PR DESCRIPTION
This PR should not introduce any behavior changes.

As pointed out in https://github.com/posit-dev/shiny-vscode/pull/70#discussion_r1729368212, `askUserForOutputLocation()` blends the single-file app and multi-file app cases. While they follow a similar flow, there are checks that are important in one or the other case that are interleaved.

This PR separates these into two functions: `askUserForOutputFile()` and `askUserForOutputDirectory()`.

This makes it much easier to differentiate in `shinyliveSaveAppFromUrl()` how the single-file app workflow differs from the multi-file app workflow.