### PR TITLE
Wait 10s instead of 20s before asking user

### DIFF
--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -61,7 +61,8 @@ async function getTerminalClosedPromise(
 export async function openBrowserWhenReady(
   port: number,
   additionalPorts: number[] = [],
-  terminal?: vscode.Terminal
+  terminal?: vscode.Terminal,
+  timeout: number = 10000
 ): Promise<void> {
   const portsOpenResult = await vscode.window.withProgress(
     {
@@ -71,7 +72,7 @@ export async function openBrowserWhenReady(
     },
     async () => {
       const portsOpen = [port, ...additionalPorts].map((p) =>
-        retryUntilTimeout(10000, () => isPortOpen("127.0.0.1", p))
+        retryUntilTimeout(timeout, () => isPortOpen("127.0.0.1", p))
       );
 
       const portsOpenPromise = Promise.all(portsOpen);
@@ -92,8 +93,9 @@ export async function openBrowserWhenReady(
   }
 
   if (portsOpenResult.filter((p) => !p).length > 0) {
+    const timeoutStr = Math.floor(timeout / 1000);
     const action = await vscode.window.showErrorMessage(
-      "Shiny app took longer than 10s to start, not launching browser.",
+      `Shiny app took longer than ${timeoutStr}s to start, not launching browser.`,
       terminal ? "Show Shiny process" : "",
       "Keep waiting"
     );
@@ -104,7 +106,7 @@ export async function openBrowserWhenReady(
         );
         return;
       }
-      return openBrowserWhenReady(port, additionalPorts, terminal);
+      return openBrowserWhenReady(port, additionalPorts, terminal, 30000);
     }
     if (action === "Show Shiny process") {
       terminal?.show();

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -39,7 +39,9 @@ async function isPortOpen(
   });
 }
 
-async function getTerminalClosedPromise(terminal: vscode.Terminal): Promise<boolean> {
+async function getTerminalClosedPromise(
+  terminal: vscode.Terminal
+): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     vscode.window.onDidCloseTerminal((term) => {
       if (term === terminal) {
@@ -76,7 +78,10 @@ export async function openBrowserWhenReady(
       if (!terminal) {
         return portsOpenPromise;
       } else {
-        return Promise.race([portsOpenPromise, getTerminalClosedPromise(terminal)]);
+        return Promise.race([
+          portsOpenPromise,
+          getTerminalClosedPromise(terminal),
+        ]);
       }
     }
   );

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -69,7 +69,7 @@ export async function openBrowserWhenReady(
     },
     async () => {
       const portsOpen = [port, ...additionalPorts].map((p) =>
-        retryUntilTimeout(20000, () => isPortOpen("127.0.0.1", p))
+        retryUntilTimeout(10000, () => isPortOpen("127.0.0.1", p))
       );
 
       const portsOpenPromise = Promise.all(portsOpen);

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -57,6 +57,10 @@ async function getTerminalClosedPromise(
  * @param port The port to open the browser for.
  * @param additionalPorts Additional ports to wait for before opening the
  * browser.
+ * @param timeout Milliseconds to wait for the port to open before letting the
+ * user know something is wrong and asking if they'd like to check on the Shiny
+ * process or keep waiting. We start with a low 10s wait because some apps might
+ * fail quickly, but we increase to 30s if the user chooses to keep waiting.
  */
 export async function openBrowserWhenReady(
   port: number,


### PR DESCRIPTION
I initially had a 10s wait before the "would you like to continue" appears, but in https://github.com/posit-dev/shiny-vscode/pull/65#discussion_r1686848560 we bumped this to 20s.

I had forgotten that these 10s are balancing both slow-opening apps as well as apps that fail immediately. Because we're using `terminal.sendText()`, we don't have any insight into what has happened in the Terminal. When an app fails immediately (say `shiny` isn't installed), we still have to wait for the 10s timeout before we show the "something's not right dialog".

To mitigate this, if the user clicks "keep waiting", we'll bump up the wait time to 30s.