### PR TITLE
Wait until server port is available before starting app

### DIFF
--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -40,9 +40,8 @@ async function isPortOpen(
 }
 
 /**
- * Repeatedly attempts to connect to a specified port until it becomes available
- * or times out. Uses a shorter connection timeout (200ms) for each attempt
- * while respecting the overall timeout period.
+ * Repeatedly attempts to listen on a specified port until it becomes available
+ * or times out. Retries every 80ms until the timeout.
  *
  * @param port - The port number to check
  * @param timeout - Maximum time in milliseconds to wait for the port to open

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -57,7 +57,6 @@ export async function waitUntilServerPortIsAvailable(
   const portIsOpen: true | undefined = await retryUntilTimeout(
     timeout,
     async (): Promise<true> => {
-      console.log(`Checking if port ${port} is open...`);
       if ((await isServerPortAvailable(port)) === true) {
         return true;
       } else {

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -39,6 +39,64 @@ async function isPortOpen(
   });
 }
 
+/**
+ * Repeatedly attempts to connect to a specified port until it becomes available
+ * or times out. Uses a shorter connection timeout (200ms) for each attempt
+ * while respecting the overall timeout period.
+ *
+ * @param port - The port number to check
+ * @param timeout - Maximum time in milliseconds to wait for the port to open
+ * (default: 1000ms)
+ * @returns A promise that resolves to true if the port opens within the timeout
+ * period, false otherwise
+ */
+export async function waitUntilServerPortIsAvailable(
+  port: number,
+  timeout: number = 1000
+): Promise<boolean> {
+  const portIsOpen: true | undefined = await retryUntilTimeout(
+    timeout,
+    async (): Promise<true> => {
+      console.log(`Checking if port ${port} is open...`);
+      if ((await isServerPortAvailable(port)) === true) {
+        return true;
+      } else {
+        // This callback needs to throw an error for the retry to happen.
+        throw new Error(`Port ${port} is not open yet`);
+      }
+    },
+    80
+  );
+  if (portIsOpen === true) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Checks if a port is available for a server to listen on by attempting to
+ * create an HTTP server on that port. This is more reliable than TCP connection
+ * tests for determining if a port can be used by a server.
+ *
+ * @param port - The port number to check for availability
+ * @returns A promise that resolves to true if the port is available for use,
+ *          false if the port is already in use or cannot be bound to.
+ */
+export async function isServerPortAvailable(port: number): Promise<boolean> {
+  const server = http.createServer();
+
+  const p = new Promise<boolean>((resolve, reject) => {
+    server.on("listening", () => resolve(true));
+    server.on("error", () => resolve(false));
+  }).finally(() => {
+    return closeServer(server);
+  });
+
+  server.listen(port, "127.0.0.1");
+
+  return p;
+}
+
 async function getTerminalClosedPromise(
   terminal: vscode.Terminal
 ): Promise<boolean> {
@@ -57,7 +115,8 @@ async function getTerminalClosedPromise(
  */
 function configShinyTimeoutOpenBrowser(): number {
   return (
-    vscode.workspace.getConfiguration().get("shiny.timeoutOpenBrowser", 10) * 1000
+    vscode.workspace.getConfiguration().get("shiny.timeoutOpenBrowser", 10) *
+    1000
   );
 }
 

--- a/src/retry-utils.ts
+++ b/src/retry-utils.ts
@@ -9,9 +9,13 @@
  */
 export async function retryUntilTimeout<T>(
   timeoutMs: number,
-  callback: () => Promise<T>
+  callback: () => Promise<T>,
+  retryIntervalMs: number = 20
 ): Promise<T | undefined> {
-  const { result, cancel: cancelResult } = retryUntilCancel(20, callback);
+  const { result, cancel: cancelResult } = retryUntilCancel(
+    retryIntervalMs,
+    callback
+  );
 
   let timer: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise<undefined>((resolve) => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -62,15 +62,14 @@ export async function pyRunApp(): Promise<void> {
     waitUntilServerPortIsAvailable(autoreloadPort),
   ]);
 
-  if (!serverPortsAvailable.every((x) => x)) {
-    if (!serverPortsAvailable[0]) {
-      vscode.window.showErrorMessage(`Unable to open server port ${port}.`);
-    }
-    if (!serverPortsAvailable[1]) {
-      vscode.window.showErrorMessage(
-        `Unable to open auto-reload port ${autoreloadPort}.`
-      );
-    }
+  if (!serverPortsAvailable[0]) {
+    vscode.window.showErrorMessage(`Unable to open server port ${port}.`);
+    return;
+  }
+  if (!serverPortsAvailable[1]) {
+    vscode.window.showErrorMessage(
+      `Unable to open auto-reload port ${autoreloadPort}.`
+    );
     return;
   }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -180,6 +180,12 @@ export async function rRunApp(): Promise<void> {
     },
   });
 
+  // Wait until the server port and auto-reload ports are both available.
+  if (!(await waitUntilServerPortIsAvailable(port))) {
+    vscode.window.showErrorMessage(`Unable to open server port ${port}.`);
+    return;
+  }
+
   const useDevmode = vscode.workspace
     .getConfiguration("shiny.r")
     .get("devmode");

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,7 +5,11 @@ import * as vscode from "vscode";
 import * as winreg from "winreg";
 import { isShinyAppRPart } from "./extension";
 import { getPositronPreferredRuntime } from "./extension-api-utils/extensionHost";
-import { openBrowser, openBrowserWhenReady } from "./net-utils";
+import {
+  openBrowser,
+  openBrowserWhenReady,
+  waitUntilServerPortIsAvailable,
+} from "./net-utils";
 import { getAppPort, getAutoreloadPort } from "./port-settings";
 import {
   envVarsForShell as envVarsForTerminal,
@@ -51,6 +55,24 @@ export async function pyRunApp(): Promise<void> {
       ...envVarsForTerminal(),
     },
   });
+
+  // Wait until the server port and auto-reload ports are both available.
+  const serverPortsAvailable = await Promise.all([
+    waitUntilServerPortIsAvailable(port),
+    waitUntilServerPortIsAvailable(autoreloadPort),
+  ]);
+
+  if (!serverPortsAvailable.every((x) => x)) {
+    if (!serverPortsAvailable[0]) {
+      vscode.window.showErrorMessage(`Unable to open server port ${port}.`);
+    }
+    if (!serverPortsAvailable[1]) {
+      vscode.window.showErrorMessage(
+        `Unable to open auto-reload port ${autoreloadPort}.`
+      );
+    }
+    return;
+  }
 
   const args: string[] = ["-m", "shiny", "run"];
   args.push("--port", port + "");


### PR DESCRIPTION
When I press the Play/Run button when the Shiny app is already running, I see this error:

![image](https://github.com/user-attachments/assets/1666b695-186d-4e6d-99c0-895b0bcfcdf4)

This happens because the extension tries to execute `shiny run` before the ports have been released by the system.

This PR makes it wait until the ports are released before it tries to start the app again.