### PR TITLE
Run Shiny app in console session in Positron

### DIFF
--- a/src/extension-api-utils/extensionHost.ts
+++ b/src/extension-api-utils/extensionHost.ts
@@ -8,6 +8,7 @@
 
 import type * as positron from "positron";
 import * as vscode from "vscode";
+import type { PositronRunApp } from "../positron-run-app";
 
 type PositronApi = typeof positron;
 export type PreviewSource = positron.PreviewSource;
@@ -92,4 +93,34 @@ export function getIdeName() {
   } else {
     return "VS Code";
   }
+}
+
+/**
+ * Get the `positron-run-app` extension API, if available and if it supports
+ * `runApplicationInConsole`. Returns `undefined` in VS Code or in older
+ * Positron versions that lack the console method.
+ */
+export async function getPositronRunAppApi(): Promise<
+  PositronRunApp | undefined
+> {
+  const ext =
+    vscode.extensions.getExtension<PositronRunApp>(
+      "positron.positron-run-app"
+    );
+  if (!ext) {
+    return undefined;
+  }
+
+  // Check that we've got a sufficiently recent version of Positron
+  let api: PositronRunApp | undefined;
+  try {
+    api = ext.isActive ? ext.exports : await ext.activate();
+  } catch {
+    return undefined;
+  }
+  if (typeof api?.runApplicationInConsole !== "function") {
+    return undefined;
+  }
+
+  return api;
 }

--- a/src/positron-run-app.d.ts
+++ b/src/positron-run-app.d.ts
@@ -1,0 +1,161 @@
+import type * as positron from 'positron';
+import type * as vscode from 'vscode';
+
+/**
+ * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
+ */
+export interface RunAppTerminalOptions {
+	/**
+	 * The command line to run in the terminal.
+	 */
+	commandLine: string;
+
+	/**
+	 * The optional environment variables to create the terminal with.
+	 */
+	env?: { [key: string]: string | null | undefined };
+}
+
+/**
+ * Represents the code returned from ${@link RunConsoleAppOptions.getConsoleCode}.
+ */
+export interface RunAppConsoleCode {
+	/**
+	 * The code to execute in the console session.
+	 */
+	code: string;
+}
+
+/**
+ * Shared options for running an application.
+ */
+interface RunAppOptionsBase {
+	/**
+	 * The human-readable label for the application e.g. `'Streamlit'`.
+	 */
+	name: string;
+
+	/**
+	 * The optional URL path at which to preview the application.
+	 */
+	urlPath?: string;
+
+	/**
+	 * The optional app ready message to wait for before previewing the application.
+	 */
+	appReadyMessage?: string;
+
+	/**
+	 * An optional array of app URI formats to parse the URI from the output.
+	 */
+	appUrlStrings?: string[];
+}
+
+/**
+ * Represents options for the ${@link PositronRunApp.runApplication} function.
+ */
+export interface RunAppOptions extends RunAppOptionsBase {
+	/**
+	 * A function that will be called to get the terminal options for running the application.
+	 *
+	 * @param runtime The language runtime metadata for the document's language.
+	 * @param document The document to run.
+	 * @param urlPrefix The URL prefix to use, if known.
+	 * @returns The terminal options for running the application. Return `undefined` to abort the run.
+	 */
+	getTerminalOptions: (
+		runtime: positron.LanguageRuntimeMetadata,
+		document: vscode.TextDocument,
+		urlPrefix?: string,
+	) => RunAppTerminalOptions | undefined | Promise<RunAppTerminalOptions | undefined>;
+}
+
+/**
+ * Represents options for the ${@link PositronRunApp.runApplicationInConsole} function.
+ */
+export interface RunConsoleAppOptions extends RunAppOptionsBase {
+	/**
+	 * A function that will be called to get the code to execute in the console session.
+	 *
+	 * @param runtime The language runtime metadata for the document's language.
+	 * @param document The document to run.
+	 * @param urlPrefix The URL prefix to use, if known.
+	 * @returns The console code for running the application. Return `undefined` to abort the run.
+	 */
+	getConsoleCode: (
+		runtime: positron.LanguageRuntimeMetadata,
+		document: vscode.TextDocument,
+		urlPrefix?: string,
+	) => RunAppConsoleCode | undefined | Promise<RunAppConsoleCode | undefined>;
+}
+
+/**
+ * Represents options for the ${@link PositronRunApp.debugApplication} function.
+ */
+export interface DebugAppOptions {
+	/**
+	 * The human-readable label for the application e.g. `'Streamlit'`.
+	 */
+	name: string;
+
+	/**
+	 * A function that will be called to get the ${@link vscode.DebugConfiguration, debug configuration} for debugging the application.
+	 *
+	 * @param runtime The language runtime metadata for the document's language.
+	 * @param document The document to debug.
+	 * @param urlPrefix The URL prefix to use, if known.
+	 * @returns The debug configuration for debugging the application. Return `undefined` to abort debugging.
+	 */
+	getDebugConfiguration(
+		runtime: positron.LanguageRuntimeMetadata,
+		document: vscode.TextDocument,
+		urlPrefix?: string,
+	): vscode.DebugConfiguration | undefined | Promise<vscode.DebugConfiguration | undefined>;
+
+	/**
+	 * The optional URL path at which to preview the application.
+	 */
+	urlPath?: string;
+
+	/**
+	 * The optional app ready message to wait for in the terminal before previewing the application.
+	 */
+	appReadyMessage?: string;
+
+	/**
+	 * An optional array of app URI formats to parse the URI from the terminal output.
+	 */
+	appUrlStrings?: string[];
+}
+
+/**
+ * The public API of the Positron Run App extension.
+ */
+export interface PositronRunApp {
+	/**
+	 * Run an application in the terminal.
+	 *
+	 * @param options Options for running the application.
+	 * @returns If terminal shell integration is supported, resolves when the application server has
+	 *  started, otherwise resolves when the command has been sent to the terminal.
+	 */
+	runApplication(options: RunAppOptions): Promise<void>;
+
+	/**
+	 * Run an application in a new console session.
+	 *
+	 * @param options Options for running the application.
+	 * @returns Resolves when the application server has started, or when the
+	 *  code has been sent to the console if URL detection times out.
+	 */
+	runApplicationInConsole(options: RunConsoleAppOptions): Promise<void>;
+
+	/**
+	 * Debug an application.
+	 *
+	 * @param options Options for debugging the application.
+	 * @returns If terminal shell integration is supported, resolves when the application server has
+	 *  started, otherwise resolves when the debug session has started.
+	 */
+	debugApplication(options: DebugAppOptions): Promise<void>;
+}

--- a/src/positron-run-app.d.ts
+++ b/src/positron-run-app.d.ts
@@ -1,8 +1,14 @@
-import type * as positron from 'positron';
-import type * as vscode from 'vscode';
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import * as vscode from 'vscode';
 
 /**
- * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
+ * Options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
 	/**
@@ -17,7 +23,7 @@ export interface RunAppTerminalOptions {
 }
 
 /**
- * Represents the code returned from ${@link RunConsoleAppOptions.getConsoleCode}.
+ * Code returned from ${@link RunConsoleAppOptions.getConsoleCode}.
  */
 export interface RunAppConsoleCode {
 	/**
@@ -49,10 +55,18 @@ interface RunAppOptionsBase {
 	 * An optional array of app URI formats to parse the URI from the output.
 	 */
 	appUrlStrings?: string[];
+
+	/**
+	 * The debug adapter type (e.g. `'ark'`) used by the runtime. When set
+	 * and breakpoints are present, the runner waits for that adapter's
+	 * `configurationDone` before executing app code. Leave unset for
+	 * runtimes without DAP support to avoid a waiting overhead on every run.
+	 */
+	debugAdapterType?: string;
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.runApplication} function.
+ * Options for the ${@link PositronRunApp.runApplication} function.
  */
 export interface RunAppOptions extends RunAppOptionsBase {
 	/**
@@ -71,7 +85,7 @@ export interface RunAppOptions extends RunAppOptionsBase {
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.runApplicationInConsole} function.
+ * Options for the ${@link PositronRunApp.runApplicationInConsole} function.
  */
 export interface RunConsoleAppOptions extends RunAppOptionsBase {
 	/**
@@ -90,7 +104,7 @@ export interface RunConsoleAppOptions extends RunAppOptionsBase {
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.debugApplication} function.
+ * Options for the ${@link PositronRunApp.debugApplication} function.
  */
 export interface DebugAppOptions {
 	/**

--- a/src/run.ts
+++ b/src/run.ts
@@ -341,6 +341,7 @@ async function runShinyAppInConsole(
   appUrlStrings: string[],
   buildCode: (appPath: string, port: number, cwd: string) => string,
 ): Promise<void> {
+  await saveActiveEditorFile();
   await api.runApplicationInConsole({
     name: "Shiny",
     async getConsoleCode(_runtime, document, _urlPrefix) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -83,31 +83,7 @@ export function registerTerminalCloseHandler(): vscode.Disposable {
 
 /* Shiny for Python --------------------------------------------------------- */
 
-function buildPyConsoleCode(appPath: string, port: number, cwd: string): string {
-  const args = [
-    JSON.stringify(appPath),
-    `host="127.0.0.1"`,
-    `port=${port}`,
-    `reload=True`,
-    `launch_browser=False`,
-  ];
-  return [
-    `import os; os.chdir(${JSON.stringify(cwd)})`,
-    `import shiny; shiny.run_app(${args.join(", ")})`,
-  ].join("\n");
-}
-
 export async function pyRunApp(): Promise<void> {
-  const runAppApi = await getPositronRunAppApi();
-  if (runAppApi) {
-    return runShinyAppInConsole(
-      runAppApi,
-      "python",
-      ["Uvicorn running on {{APP_URL}}"],
-      buildPyConsoleCode,
-    );
-  }
-
   const path = getActiveEditorFile();
   if (!path) {
     return;

--- a/src/run.ts
+++ b/src/run.ts
@@ -83,26 +83,29 @@ export function registerTerminalCloseHandler(): vscode.Disposable {
 
 /* Shiny for Python --------------------------------------------------------- */
 
+function buildPyConsoleCode(appPath: string, port: number, cwd: string): string {
+  const args = [
+    JSON.stringify(appPath),
+    `host="127.0.0.1"`,
+    `port=${port}`,
+    `reload=True`,
+    `launch_browser=False`,
+  ];
+  return [
+    `import os; os.chdir(${JSON.stringify(cwd)})`,
+    `import shiny; shiny.run_app(${args.join(", ")})`,
+  ].join("\n");
+}
+
 export async function pyRunApp(): Promise<void> {
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    return runShinyAppInConsole(runAppApi, {
-      language: "python",
-      appUrlStrings: ["Uvicorn running on {{APP_URL}}"],
-      buildCode({ appPath, port, cwd }) {
-        const args = [
-          JSON.stringify(appPath),
-          `host="127.0.0.1"`,
-          `port=${port}`,
-          `reload=True`,
-          `launch_browser=False`,
-        ];
-        return [
-          `import os; os.chdir(${JSON.stringify(cwd)})`,
-          `import shiny; shiny.run_app(${args.join(", ")})`,
-        ].join("\n");
-      },
-    });
+    return runShinyAppInConsole(
+      runAppApi,
+      "python",
+      ["Uvicorn running on {{APP_URL}}"],
+      buildPyConsoleCode,
+    );
   }
 
   const path = getActiveEditorFile();
@@ -249,33 +252,38 @@ export async function pyDebugApp(): Promise<void> {
 }
 
 /* Shiny for R --------------------------------------------------------- */
+
+function buildRConsoleCode(appPath: string, port: number, cwd: string): string {
+  const path = isShinyAppRPart(appPath) ? path_dirname(appPath) : appPath;
+  const useDevmode = vscode.workspace
+    .getConfiguration("shiny.r")
+    .get("devmode");
+
+  const lines: string[] = [];
+  lines.push(`setwd(${JSON.stringify(cwd)})`);
+
+  if (useDevmode) {
+    lines.push("shiny::devmode()");
+  } else {
+    lines.push("options(shiny.autoreload = TRUE)");
+  }
+
+  lines.push(
+    `shiny::runApp(${JSON.stringify(path)}, port = ${port}L, launch.browser = FALSE)`
+  );
+
+  return lines.join("\n");
+}
+
 export async function rRunApp(): Promise<void> {
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    return runShinyAppInConsole(runAppApi, {
-      language: "r",
-      appUrlStrings: ["Listening on {{APP_URL}}"],
-      buildCode({ appPath, port, cwd }) {
-        const path = isShinyAppRPart(appPath)
-          ? path_dirname(appPath)
-          : appPath;
-        const useDevmode = vscode.workspace
-          .getConfiguration("shiny.r")
-          .get("devmode");
-
-        const lines: string[] = [];
-        lines.push(`setwd(${JSON.stringify(cwd)})`);
-        if (useDevmode) {
-          lines.push("shiny::devmode()");
-        } else {
-          lines.push("options(shiny.autoreload = TRUE)");
-        }
-        lines.push(
-          `shiny::runApp(${JSON.stringify(path)}, port = ${port}L, launch.browser = FALSE)`
-        );
-        return lines.join("\n");
-      },
-    });
+    return runShinyAppInConsole(
+      runAppApi,
+      "r",
+      ["Listening on {{APP_URL}}"],
+      buildRConsoleCode,
+    );
   }
 
   const pathFile = getActiveEditorFile();
@@ -353,21 +361,19 @@ export async function rRunApp(): Promise<void> {
 
 async function runShinyAppInConsole(
   api: PositronRunApp,
-  options: {
-    language: "python" | "r";
-    appUrlStrings: string[];
-    buildCode(params: { appPath: string; port: number; cwd: string }): string;
-  }
+  language: "python" | "r",
+  appUrlStrings: string[],
+  buildCode: (appPath: string, port: number, cwd: string) => string,
 ): Promise<void> {
   await api.runApplicationInConsole({
     name: "Shiny",
     async getConsoleCode(_runtime, document, _urlPrefix) {
       const appPath = document.uri.fsPath;
-      const port = await getAppPort("run", options.language);
+      const port = await getAppPort("run", language);
       const cwd = await resolveWorkingDirectory(appPath);
-      return { code: options.buildCode({ appPath, port, cwd }) };
+      return { code: buildCode(appPath, port, cwd) };
     },
-    appUrlStrings: options.appUrlStrings,
+    appUrlStrings,
   });
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,7 +4,10 @@ import { dirname as path_dirname, join as path_join } from "path";
 import * as vscode from "vscode";
 import * as winreg from "winreg";
 import { isShinyAppRPart } from "./extension";
-import { getPositronPreferredRuntime } from "./extension-api-utils/extensionHost";
+import {
+  getPositronPreferredRuntime,
+  getPositronRunAppApi,
+} from "./extension-api-utils/extensionHost";
 import {
   openBrowser,
   openBrowserWhenReady,
@@ -16,6 +19,7 @@ import {
   escapeCommandForTerminal,
 } from "./shell-utils";
 import { resolveWorkingDirectory } from "./working-directory";
+import type { PositronRunApp } from "./positron-run-app";
 
 const DEBUG_NAME = "Debug Shiny app";
 
@@ -80,6 +84,11 @@ export function registerTerminalCloseHandler(): vscode.Disposable {
 /* Shiny for Python --------------------------------------------------------- */
 
 export async function pyRunApp(): Promise<void> {
+  const runAppApi = await getPositronRunAppApi();
+  if (runAppApi) {
+    return pyRunAppInConsole(runAppApi);
+  }
+
   const path = getActiveEditorFile();
   if (!path) {
     return;
@@ -177,6 +186,33 @@ export async function pyRunApp(): Promise<void> {
   }
 }
 
+async function pyRunAppInConsole(api: PositronRunApp): Promise<void> {
+  await api.runApplicationInConsole({
+    name: "Shiny",
+    async getConsoleCode(_runtime, document, _urlPrefix) {
+      const appPath = document.uri.fsPath;
+      const port = await getAppPort("run", "python");
+      const cwd = await resolveWorkingDirectory(appPath);
+
+      const runAppArgs = [
+        JSON.stringify(appPath),
+        `host="127.0.0.1"`,
+        `port=${port}`,
+        `reload=True`,
+        `launch_browser=False`,
+      ];
+
+      const code = [
+        `import os; os.chdir(${JSON.stringify(cwd)})`,
+        `import shiny; shiny.run_app(${runAppArgs.join(", ")})`,
+      ].join("\n");
+
+      return { code };
+    },
+    appUrlStrings: ["Uvicorn running on {{APP_URL}}"],
+  });
+}
+
 export async function pyDebugApp(): Promise<void> {
   if (vscode.debug.activeDebugSession?.name === DEBUG_NAME) {
     await vscode.debug.stopDebugging(vscode.debug.activeDebugSession);
@@ -225,6 +261,11 @@ export async function pyDebugApp(): Promise<void> {
 
 /* Shiny for R --------------------------------------------------------- */
 export async function rRunApp(): Promise<void> {
+  const runAppApi = await getPositronRunAppApi();
+  if (runAppApi) {
+    return rRunAppInConsole(runAppApi);
+  }
+
   const pathFile = getActiveEditorFile();
   if (!pathFile) {
     return;
@@ -297,6 +338,41 @@ export async function rRunApp(): Promise<void> {
   // TODO: Support Codespaces
   await openBrowserWhenReady(port, [], terminal);
 }
+
+async function rRunAppInConsole(api: PositronRunApp): Promise<void> {
+  await api.runApplicationInConsole({
+    name: "Shiny",
+    async getConsoleCode(_runtime, document, _urlPrefix) {
+      const appFilePath = document.uri.fsPath;
+      const appPath = isShinyAppRPart(appFilePath)
+        ? path_dirname(appFilePath)
+        : appFilePath;
+      const port = await getAppPort("run", "r");
+      const cwd = await resolveWorkingDirectory(appFilePath);
+
+      const useDevmode = vscode.workspace
+        .getConfiguration("shiny.r")
+        .get("devmode");
+
+      const lines: string[] = [];
+      lines.push(`setwd(${JSON.stringify(cwd)})`);
+
+      if (useDevmode) {
+        lines.push("shiny::devmode()");
+      } else {
+        lines.push("options(shiny.autoreload = TRUE)");
+      }
+
+      lines.push(
+        `shiny::runApp(${JSON.stringify(appPath)}, port = ${port}L, launch.browser = FALSE)`
+      );
+
+      return { code: lines.join("\n") };
+    },
+    appUrlStrings: ["Listening on {{APP_URL}}"],
+  });
+}
+
 
 /* Utilities --------------------------------------------------------- */
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -86,7 +86,23 @@ export function registerTerminalCloseHandler(): vscode.Disposable {
 export async function pyRunApp(): Promise<void> {
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    return pyRunAppInConsole(runAppApi);
+    return runShinyAppInConsole(runAppApi, {
+      language: "python",
+      appUrlStrings: ["Uvicorn running on {{APP_URL}}"],
+      buildCode({ appPath, port, cwd }) {
+        const args = [
+          JSON.stringify(appPath),
+          `host="127.0.0.1"`,
+          `port=${port}`,
+          `reload=True`,
+          `launch_browser=False`,
+        ];
+        return [
+          `import os; os.chdir(${JSON.stringify(cwd)})`,
+          `import shiny; shiny.run_app(${args.join(", ")})`,
+        ].join("\n");
+      },
+    });
   }
 
   const path = getActiveEditorFile();
@@ -186,33 +202,6 @@ export async function pyRunApp(): Promise<void> {
   }
 }
 
-async function pyRunAppInConsole(api: PositronRunApp): Promise<void> {
-  await api.runApplicationInConsole({
-    name: "Shiny",
-    async getConsoleCode(_runtime, document, _urlPrefix) {
-      const appPath = document.uri.fsPath;
-      const port = await getAppPort("run", "python");
-      const cwd = await resolveWorkingDirectory(appPath);
-
-      const runAppArgs = [
-        JSON.stringify(appPath),
-        `host="127.0.0.1"`,
-        `port=${port}`,
-        `reload=True`,
-        `launch_browser=False`,
-      ];
-
-      const code = [
-        `import os; os.chdir(${JSON.stringify(cwd)})`,
-        `import shiny; shiny.run_app(${runAppArgs.join(", ")})`,
-      ].join("\n");
-
-      return { code };
-    },
-    appUrlStrings: ["Uvicorn running on {{APP_URL}}"],
-  });
-}
-
 export async function pyDebugApp(): Promise<void> {
   if (vscode.debug.activeDebugSession?.name === DEBUG_NAME) {
     await vscode.debug.stopDebugging(vscode.debug.activeDebugSession);
@@ -263,7 +252,30 @@ export async function pyDebugApp(): Promise<void> {
 export async function rRunApp(): Promise<void> {
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    return rRunAppInConsole(runAppApi);
+    return runShinyAppInConsole(runAppApi, {
+      language: "r",
+      appUrlStrings: ["Listening on {{APP_URL}}"],
+      buildCode({ appPath, port, cwd }) {
+        const path = isShinyAppRPart(appPath)
+          ? path_dirname(appPath)
+          : appPath;
+        const useDevmode = vscode.workspace
+          .getConfiguration("shiny.r")
+          .get("devmode");
+
+        const lines: string[] = [];
+        lines.push(`setwd(${JSON.stringify(cwd)})`);
+        if (useDevmode) {
+          lines.push("shiny::devmode()");
+        } else {
+          lines.push("options(shiny.autoreload = TRUE)");
+        }
+        lines.push(
+          `shiny::runApp(${JSON.stringify(path)}, port = ${port}L, launch.browser = FALSE)`
+        );
+        return lines.join("\n");
+      },
+    });
   }
 
   const pathFile = getActiveEditorFile();
@@ -339,40 +351,25 @@ export async function rRunApp(): Promise<void> {
   await openBrowserWhenReady(port, [], terminal);
 }
 
-async function rRunAppInConsole(api: PositronRunApp): Promise<void> {
+async function runShinyAppInConsole(
+  api: PositronRunApp,
+  options: {
+    language: "python" | "r";
+    appUrlStrings: string[];
+    buildCode(params: { appPath: string; port: number; cwd: string }): string;
+  }
+): Promise<void> {
   await api.runApplicationInConsole({
     name: "Shiny",
     async getConsoleCode(_runtime, document, _urlPrefix) {
-      const appFilePath = document.uri.fsPath;
-      const appPath = isShinyAppRPart(appFilePath)
-        ? path_dirname(appFilePath)
-        : appFilePath;
-      const port = await getAppPort("run", "r");
-      const cwd = await resolveWorkingDirectory(appFilePath);
-
-      const useDevmode = vscode.workspace
-        .getConfiguration("shiny.r")
-        .get("devmode");
-
-      const lines: string[] = [];
-      lines.push(`setwd(${JSON.stringify(cwd)})`);
-
-      if (useDevmode) {
-        lines.push("shiny::devmode()");
-      } else {
-        lines.push("options(shiny.autoreload = TRUE)");
-      }
-
-      lines.push(
-        `shiny::runApp(${JSON.stringify(appPath)}, port = ${port}L, launch.browser = FALSE)`
-      );
-
-      return { code: lines.join("\n") };
+      const appPath = document.uri.fsPath;
+      const port = await getAppPort("run", options.language);
+      const cwd = await resolveWorkingDirectory(appPath);
+      return { code: options.buildCode({ appPath, port, cwd }) };
     },
-    appUrlStrings: ["Listening on {{APP_URL}}"],
+    appUrlStrings: options.appUrlStrings,
   });
 }
-
 
 /* Utilities --------------------------------------------------------- */
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -254,13 +254,12 @@ function buildRConsoleCode(appPath: string, port: number, cwd: string): string {
 export async function rRunApp(): Promise<void> {
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    return runShinyAppInConsole(
-      runAppApi,
-      "r",
-      ["Listening on {{APP_URL}}"],
-      buildRConsoleCode,
-      "ark",
-    );
+    return runShinyAppInConsole(runAppApi, {
+      language: "r",
+      appUrlStrings: ["Listening on {{APP_URL}}"],
+      buildCode: buildRConsoleCode,
+      debugAdapterType: "ark",
+    });
   }
 
   const pathFile = getActiveEditorFile();
@@ -336,24 +335,28 @@ export async function rRunApp(): Promise<void> {
   await openBrowserWhenReady(port, [], terminal);
 }
 
+interface ConsoleAppOptions {
+  language: "python" | "r";
+  appUrlStrings: string[];
+  buildCode: (appPath: string, port: number, cwd: string) => string;
+  debugAdapterType?: string;
+}
+
 async function runShinyAppInConsole(
   api: PositronRunApp,
-  language: "python" | "r",
-  appUrlStrings: string[],
-  buildCode: (appPath: string, port: number, cwd: string) => string,
-  debugAdapterType?: string,
+  opts: ConsoleAppOptions,
 ): Promise<void> {
   await saveActiveEditorFile();
   await api.runApplicationInConsole({
     name: "Shiny",
-    debugAdapterType,
+    debugAdapterType: opts.debugAdapterType,
     async getConsoleCode(_runtime, document, _urlPrefix) {
       const appPath = document.uri.fsPath;
-      const port = await getAppPort("run", language);
+      const port = await getAppPort("run", opts.language);
       const cwd = await resolveWorkingDirectory(appPath);
-      return { code: buildCode(appPath, port, cwd) };
+      return { code: opts.buildCode(appPath, port, cwd) };
     },
-    appUrlStrings,
+    appUrlStrings: opts.appUrlStrings,
   });
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -259,6 +259,7 @@ export async function rRunApp(): Promise<void> {
       "r",
       ["Listening on {{APP_URL}}"],
       buildRConsoleCode,
+      "ark",
     );
   }
 
@@ -340,10 +341,12 @@ async function runShinyAppInConsole(
   language: "python" | "r",
   appUrlStrings: string[],
   buildCode: (appPath: string, port: number, cwd: string) => string,
+  debugAdapterType?: string,
 ): Promise<void> {
   await saveActiveEditorFile();
   await api.runApplicationInConsole({
     name: "Shiny",
+    debugAdapterType,
     async getConsoleCode(_runtime, document, _urlPrefix) {
       const appPath = document.uri.fsPath;
       const port = await getAppPort("run", language);


### PR DESCRIPTION
Part of https://github.com/posit-dev/positron/issues/12556
Uses new API from https://github.com/posit-dev/positron/pull/12545

Now that Positron has multi-console session, we can run Shiny apps in regular sidecar sessions without occupying the user's own sessions. This has the benefit of enabling full debugger support for the Shiny app.

- The implementation is defensive, we check that the version of Positron is sufficiently recent, otherwise we fall back to the regular terminal path.

- I left it R-only. I initially drafted the Python path too but reverted it because I'm not sure how things like debugging work on the Python side. See commit for the work in progress.

https://github.com/user-attachments/assets/004a6f65-21f5-45d9-9edc-2d922b1e1999

