### PR TITLE
Pass new `preview` option to positron-run-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,14 +165,16 @@
           "type": "string",
           "description": "Where should the Shiny app preview open?",
           "enum": [
+            "default",
             "internal",
             "simple browser",
             "external",
             "none"
           ],
-          "default": "internal",
+          "default": "default",
           "enumDescriptions": [
-            "Preview using the default internal preview in Positron (see positron.runApp.previewMode) or the Simple Browser in VS Code",
+            "Use the default preview mode. In Positron, see `positron.runApp.previewMode`. In VS Code, uses the Simple Browser.",
+            "Preview using the Viewer pane in Positron or the Simple Browser in VS Code",
             "Preview using the Simple Browser (an internal, basic browser preview)",
             "Preview using an external web browser",
             "Don't automatically launch the app after starting"

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
           "order": 2,
           "type": "integer",
           "default": 10,
+          "minimum": 1,
           "description": "Maximum wait time (in seconds) for the Shiny app to be ready before opening the browser."
         },
         "shiny.runFrom": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
           ],
           "default": "internal",
           "enumDescriptions": [
-            "Preview using the viewer pane in Positron or the Simple Browser in VS Code",
+            "Preview using the default internal preview in Positron (see positron.runApp.previewMode) or the Simple Browser in VS Code",
             "Preview using the Simple Browser (an internal, basic browser preview)",
             "Preview using an external web browser",
             "Don't automatically launch the app after starting"

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -116,11 +116,9 @@ async function getTerminalClosedPromise(
  * Reads `shiny.timeoutOpenBrowser`, which is provided in seconds.
  * @returns Open browser timeout in milliseconds.
  */
-function configShinyTimeoutOpenBrowser(): number {
-  return (
-    vscode.workspace.getConfiguration().get("shiny.timeoutOpenBrowser", 10) *
-    1000
-  );
+export function configShinyTimeoutOpenBrowser(): number {
+  const seconds = vscode.workspace.getConfiguration().get<number>("shiny.timeoutOpenBrowser", 10);
+  return Math.max(1, seconds) * 1000;
 }
 
 /**

--- a/src/positron-run-app.d.ts
+++ b/src/positron-run-app.d.ts
@@ -47,9 +47,12 @@ interface RunAppOptionsBase {
 	 *
 	 * - `'internal'` — open in the Positron Viewer pane.
 	 * - `'external'` — open in an external browser.
+	 * - `'simple'`   — open in the Simple Browser editor.
 	 * - `'none'`     — skip URL detection and preview entirely.
+	 * - `'manual'`   — detect the URL but return it to the caller
+	 *                   instead of previewing.
 	 */
-	preview?: 'internal' | 'external' | 'none';
+	preview?: 'internal' | 'external' | 'simple' | 'none' | 'manual';
 
 	/**
 	 * The optional URL path at which to preview the application.
@@ -160,19 +163,23 @@ export interface PositronRunApp {
 	 * Run an application in the terminal.
 	 *
 	 * @param options Options for running the application.
-	 * @returns If terminal shell integration is supported, resolves when the application server has
-	 *  started, otherwise resolves when the command has been sent to the terminal.
+	 * @returns If terminal shell integration is supported, resolves when the
+	 *  application server has started, otherwise resolves when the command has
+	 *  been sent to the terminal. When `preview` is `'manual'`, resolves with
+	 *  the detected URL (rejects if detection fails).
 	 */
-	runApplication(options: RunAppOptions): Promise<void>;
+	runApplication(options: RunAppOptions): Promise<vscode.Uri | undefined>;
 
 	/**
 	 * Run an application in a new console session.
 	 *
 	 * @param options Options for running the application.
 	 * @returns Resolves when the application server has started, or when the
-	 *  code has been sent to the console if URL detection times out.
+	 *  code has been sent to the console if URL detection times out. When
+	 *  `preview` is `'manual'`, resolves with the detected URL (rejects if
+	 *  detection fails).
 	 */
-	runApplicationInConsole(options: RunConsoleAppOptions): Promise<void>;
+	runApplicationInConsole(options: RunConsoleAppOptions): Promise<vscode.Uri | undefined>;
 
 	/**
 	 * Debug an application.

--- a/src/positron-run-app.d.ts
+++ b/src/positron-run-app.d.ts
@@ -83,6 +83,12 @@ interface RunAppOptionsBase {
 	 * runtimes without DAP support to avoid a waiting overhead on every run.
 	 */
 	debugAdapterType?: string;
+
+	/**
+	 * Optional timeout in milliseconds for URL detection in application output.
+	 * If not specified, a default timeout is used.
+	 */
+	urlDetectionTimeout?: number;
 }
 
 /**
@@ -160,6 +166,12 @@ export interface DebugAppOptions {
 	 * An optional array of app URI formats to parse the URI from the terminal output.
 	 */
 	appUrlStrings?: string[];
+
+	/**
+	 * Optional timeout in milliseconds for URL detection in application output.
+	 * If not specified, a default timeout is used.
+	 */
+	urlDetectionTimeout?: number;
 }
 
 /**

--- a/src/positron-run-app.d.ts
+++ b/src/positron-run-app.d.ts
@@ -42,6 +42,16 @@ interface RunAppOptionsBase {
 	name: string;
 
 	/**
+	 * How to preview the application once the URL is detected. Defaults
+	 * to `'internal'`.
+	 *
+	 * - `'internal'` — open in the Positron Viewer pane.
+	 * - `'external'` — open in an external browser.
+	 * - `'none'`     — skip URL detection and preview entirely.
+	 */
+	preview?: 'internal' | 'external' | 'none';
+
+	/**
 	 * The optional URL path at which to preview the application.
 	 */
 	urlPath?: string;

--- a/src/positron-run-app.d.ts
+++ b/src/positron-run-app.d.ts
@@ -33,6 +33,18 @@ export interface RunAppConsoleCode {
 }
 
 /**
+ * How to preview the application once the URL is detected.
+ *
+ * - `'viewer'`   — open in the Positron Viewer pane.
+ * - `'editor'`   — open in the Simple Browser editor.
+ * - `'external'` — open in an external browser.
+ * - `'none'`     — skip URL detection and preview entirely.
+ * - `'manual'`   — detect the URL but return it to the caller
+ *                   instead of previewing.
+ */
+export type PreviewMode = 'viewer' | 'editor' | 'external' | 'none' | 'manual';
+
+/**
  * Shared options for running an application.
  */
 interface RunAppOptionsBase {
@@ -42,17 +54,12 @@ interface RunAppOptionsBase {
 	name: string;
 
 	/**
-	 * How to preview the application once the URL is detected. Defaults
-	 * to `'internal'`.
+	 * How to preview the application once the URL is detected.
 	 *
-	 * - `'internal'` — open in the Positron Viewer pane.
-	 * - `'external'` — open in an external browser.
-	 * - `'simple'`   — open in the Simple Browser editor.
-	 * - `'none'`     — skip URL detection and preview entirely.
-	 * - `'manual'`   — detect the URL but return it to the caller
-	 *                   instead of previewing.
+	 * Defaults to `'default'`, which resolves to the user's
+	 * `positron.runApp.previewMode` setting (initially `'viewer'`).
 	 */
-	preview?: 'internal' | 'external' | 'simple' | 'none' | 'manual';
+	preview?: PreviewMode | 'default';
 
 	/**
 	 * The optional URL path at which to preview the application.

--- a/src/run.ts
+++ b/src/run.ts
@@ -19,7 +19,7 @@ import {
   escapeCommandForTerminal,
 } from "./shell-utils";
 import { resolveWorkingDirectory } from "./working-directory";
-import type { PositronRunApp } from "./positron-run-app";
+import type { PositronRunApp, PreviewMode } from "./positron-run-app";
 
 const DEBUG_NAME = "Debug Shiny app";
 
@@ -257,12 +257,12 @@ export async function rRunApp(): Promise<void> {
 
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    let preview: "internal" | "external" | "simple" | "none";
+    let preview: PreviewMode | "default";
     switch (previewType) {
       case "external": preview = "external"; break;
       case "none": preview = "none"; break;
-      case "simple browser": preview = "simple"; break;
-      default: preview = "internal"; break;
+      case "simple browser": preview = "editor"; break;
+      default: preview = "default"; break;
     }
 
     return runShinyAppInConsole(runAppApi, {
@@ -352,7 +352,7 @@ interface ConsoleAppOptions {
   appUrlStrings: string[];
   buildCode: (appPath: string, port: number, cwd: string) => string;
   debugAdapterType?: string;
-  preview?: "internal" | "external" | "simple" | "none";
+  preview?: PreviewMode | "default";
 }
 
 async function runShinyAppInConsole(

--- a/src/run.ts
+++ b/src/run.ts
@@ -254,12 +254,13 @@ function buildRConsoleCode(appPath: string, port: number, cwd: string): string {
 
 export async function rRunApp(): Promise<void> {
   const previewType =
-    vscode.workspace.getConfiguration().get<string>("shiny.previewType") || "internal";
+    vscode.workspace.getConfiguration().get<string>("shiny.previewType") || "default";
 
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
     let preview: PreviewMode | "default";
     switch (previewType) {
+      case "internal": preview = "viewer"; break;
       case "external": preview = "external"; break;
       case "none": preview = "none"; break;
       case "simple browser": preview = "editor"; break;

--- a/src/run.ts
+++ b/src/run.ts
@@ -257,11 +257,11 @@ export async function rRunApp(): Promise<void> {
 
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    // `"simple browser"` intentionally maps to `"internal"`
-    let preview: "internal" | "external" | "none";
+    let preview: "internal" | "external" | "simple" | "none";
     switch (previewType) {
       case "external": preview = "external"; break;
       case "none": preview = "none"; break;
+      case "simple browser": preview = "simple"; break;
       default: preview = "internal"; break;
     }
 
@@ -352,7 +352,7 @@ interface ConsoleAppOptions {
   appUrlStrings: string[];
   buildCode: (appPath: string, port: number, cwd: string) => string;
   debugAdapterType?: string;
-  preview?: "internal" | "external" | "none";
+  preview?: "internal" | "external" | "simple" | "none";
 }
 
 async function runShinyAppInConsole(

--- a/src/run.ts
+++ b/src/run.ts
@@ -360,6 +360,7 @@ async function runShinyAppInConsole(
   opts: ConsoleAppOptions,
 ): Promise<void> {
   await saveActiveEditorFile();
+  const timeoutSec = vscode.workspace.getConfiguration().get<number>("shiny.timeoutOpenBrowser", 10);
   await api.runApplicationInConsole({
     name: "Shiny",
     debugAdapterType: opts.debugAdapterType,
@@ -371,6 +372,7 @@ async function runShinyAppInConsole(
     },
     appUrlStrings: opts.appUrlStrings,
     preview: opts.preview,
+    urlDetectionTimeout: timeoutSec * 1000,
   });
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import {
   getPositronRunAppApi,
 } from "./extension-api-utils/extensionHost";
 import {
+  configShinyTimeoutOpenBrowser,
   openBrowser,
   openBrowserWhenReady,
   waitUntilServerPortIsAvailable,
@@ -360,7 +361,7 @@ async function runShinyAppInConsole(
   opts: ConsoleAppOptions,
 ): Promise<void> {
   await saveActiveEditorFile();
-  const timeoutSec = vscode.workspace.getConfiguration().get<number>("shiny.timeoutOpenBrowser", 10);
+  const urlDetectionTimeout = configShinyTimeoutOpenBrowser();
   await api.runApplicationInConsole({
     name: "Shiny",
     debugAdapterType: opts.debugAdapterType,
@@ -372,7 +373,7 @@ async function runShinyAppInConsole(
     },
     appUrlStrings: opts.appUrlStrings,
     preview: opts.preview,
-    urlDetectionTimeout: timeoutSec * 1000,
+    urlDetectionTimeout,
   });
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -252,13 +252,25 @@ function buildRConsoleCode(appPath: string, port: number, cwd: string): string {
 }
 
 export async function rRunApp(): Promise<void> {
+  const previewType =
+    vscode.workspace.getConfiguration().get<string>("shiny.previewType") || "internal";
+
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
+    // `"simple browser"` intentionally maps to `"internal"`
+    let preview: "internal" | "external" | "none";
+    switch (previewType) {
+      case "external": preview = "external"; break;
+      case "none": preview = "none"; break;
+      default: preview = "internal"; break;
+    }
+
     return runShinyAppInConsole(runAppApi, {
       language: "r",
       appUrlStrings: ["Listening on {{APP_URL}}"],
       buildCode: buildRConsoleCode,
       debugAdapterType: "ark",
+      preview,
     });
   }
 
@@ -340,6 +352,7 @@ interface ConsoleAppOptions {
   appUrlStrings: string[];
   buildCode: (appPath: string, port: number, cwd: string) => string;
   debugAdapterType?: string;
+  preview?: "internal" | "external" | "none";
 }
 
 async function runShinyAppInConsole(
@@ -357,6 +370,7 @@ async function runShinyAppInConsole(
       return { code: opts.buildCode(appPath, port, cwd) };
     },
     appUrlStrings: opts.appUrlStrings,
+    preview: opts.preview,
   });
 }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12856

The new Console path no longer respects the `shiny.previewType` setting. To fix this I've added a new `preview` option to positron-run-app in https://github.com/posit-dev/positron/pull/12857 to handle the "external" and "none" cases from Positron itself. The "simple browser" case maps to "internal" for simplicity.

Passing the `preview` option to older Positrons is harmless, so it's fine if users update shiny-vscode in the April release of Positron.

We should wait until https://github.com/posit-dev/positron/pull/12857 is reviewed and merged before merging here, in case of API change requests.