### PR TITLE
feat: Add shiny.python.otelInstrument setting for OTel auto-instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## (development version)
+
+- New `shiny.python.otelInstrument` option runs Python apps under OpenTelemetry zero-code auto-instrumentation by wrapping the "Run Shiny App" launch with `opentelemetry-instrument` (provided by `pip install "shiny[otel]"`). Extra wrapper arguments (e.g. `--traces_exporter console`) can be set via `shiny.python.otelInstrumentArgs`. (#111)
+
 ## 1.4.1
 
 - Pass new `preview` option to positron-run-app. (#109)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This extension contributes the following settings for Python and R.
 
 - `shiny.python.port`: The port number to listen on when running a Shiny for Python app. (By default, 0, which will choose a random port for each workspace.)
 - `shiny.python.debugJustMyCode`: When running the "Debug Shiny App" command, only step through user-written code. Disable this to allow stepping through library code. (Defaults to true.)
+- `shiny.python.otelInstrument`: When `true`, the "Run Shiny App" command launches the app under [OpenTelemetry zero-code auto-instrumentation](https://opentelemetry.io/docs/zero-code/python/) by wrapping it with `opentelemetry-instrument` (provided by `pip install "shiny[otel]"`). Configure exporters via standard `OTEL_*` environment variables or `shiny.python.otelInstrumentArgs`. Does not apply to "Debug Shiny App". (Defaults to false.)
+- `shiny.python.otelInstrumentArgs`: Additional arguments passed to `opentelemetry-instrument` when `shiny.python.otelInstrument` is enabled. For example, `["--traces_exporter", "console"]` prints spans to the terminal instead of exporting over OTLP. (Defaults to `[]`.)
 
 Note that there is no setting for Python executable path or virtual environment. This extension uses whatever Python environment the VS Code Python extension thinks is active. If you find that the "Run Shiny App" and "Debug Shiny App" commands are launching with a different version of Python or different virtual environment than you intended, use the Python extension's [Select Interpreter](https://code.visualstudio.com/docs/python/environments#_working-with-python-interpreters) command to change it.
 

--- a/package.json
+++ b/package.json
@@ -284,14 +284,29 @@
           "default": true,
           "description": "When running the \"Debug Shiny App\" command, only step through user-written code. Disable this to allow stepping through library code."
         },
-        "shiny.r.port": {
+        "shiny.python.otelInstrument": {
           "order": 12,
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Run Shiny apps under OpenTelemetry zero-code auto-instrumentation by wrapping the launch command with `opentelemetry-instrument` (provided by `pip install \"shiny[otel]\"`). Configure exporters via standard `OTEL_*` environment variables or `#shiny.python.otelInstrumentArgs#`. Applies to \"Run Shiny App\" only, not \"Debug Shiny App\"."
+        },
+        "shiny.python.otelInstrumentArgs": {
+          "order": 13,
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Additional arguments passed to `opentelemetry-instrument` when `#shiny.python.otelInstrument#` is enabled. For example, `[\"--traces_exporter\", \"console\"]` prints spans to the terminal instead of exporting over OTLP."
+        },
+        "shiny.r.port": {
+          "order": 14,
           "type": "integer",
           "default": 0,
           "description": "The port number Shiny should listen on when running a Shiny for R app. (Use 0 to choose a random port.)"
         },
         "shiny.r.devmode": {
-          "order": 13,
+          "order": 15,
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable dev mode when running a Shiny for R app by running `shiny::devmode()` before launching the app."

--- a/src/run.ts
+++ b/src/run.ts
@@ -84,6 +84,22 @@ export function registerTerminalCloseHandler(): vscode.Disposable {
 
 /* Shiny for Python --------------------------------------------------------- */
 
+/**
+ * Find the `opentelemetry-instrument` entry-point script in the same
+ * environment as the selected Python interpreter. The script must be invoked
+ * directly (there is no `python -m` equivalent), and resolving it next to the
+ * interpreter ensures we use the selected environment rather than whatever is
+ * on the PATH.
+ */
+function findOtelInstrument(pythonExecutable: string): string | undefined {
+  const binDir = path_dirname(pythonExecutable);
+  const candidates = [
+    path_join(binDir, "opentelemetry-instrument"),
+    path_join(binDir, "opentelemetry-instrument.exe"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
 export async function pyRunApp(): Promise<void> {
   const path = getActiveEditorFile();
   if (!path) {
@@ -148,7 +164,31 @@ export async function pyRunApp(): Promise<void> {
   args.push("--reload");
   args.push("--autoreload-port", autoreloadPort + "");
   args.push(path);
-  const cmdline = escapeCommandForTerminal(terminal, python, args);
+
+  let cmd = python;
+  let cmdArgs = args;
+  if (
+    vscode.workspace
+      .getConfiguration("shiny.python")
+      .get<boolean>("otelInstrument", false)
+  ) {
+    const otelInstrument = findOtelInstrument(python);
+    if (otelInstrument) {
+      const otelArgs = vscode.workspace
+        .getConfiguration("shiny.python")
+        .get<string[]>("otelInstrumentArgs", []);
+      cmd = otelInstrument;
+      cmdArgs = [...otelArgs, python, ...args];
+    } else {
+      vscode.window.showWarningMessage(
+        "The shiny.python.otelInstrument setting is enabled, but " +
+          "'opentelemetry-instrument' was not found in the selected Python " +
+          'environment. Install it with: pip install "shiny[otel]". ' +
+          "Running the app without instrumentation."
+      );
+    }
+  }
+  const cmdline = escapeCommandForTerminal(terminal, cmd, cmdArgs);
   terminal.sendText(cmdline);
 
   // Clear out the browser. Without this it can be a little confusing as to


### PR DESCRIPTION
Closes #111. Companion to posit-dev/py-shiny#2274 and posit-dev/py-shiny-site#380.

## What

- New `shiny.python.otelInstrument` setting (default off): when enabled, **Run Shiny App** wraps the launch as `<env>/opentelemetry-instrument <python> -m shiny run ...`, enabling OpenTelemetry zero-code auto-instrumentation with no app-code changes.
- New `shiny.python.otelInstrumentArgs` setting for extra wrapper args, e.g. `["--traces_exporter", "console"]` to print spans to the terminal.
- The `opentelemetry-instrument` entry-point script is resolved **next to the selected interpreter** (there is no `python -m` equivalent — the package has no `__main__`), so the selected environment is used rather than whatever is on `PATH`. If it isn't installed, the app runs uninstrumented and a warning suggests `pip install "shiny[otel]"`.
- Scope: *Run* only; *Debug* (`vscode.debug.startDebugging` with `module: shiny`) doesn't compose trivially with the wrapper and is left as a follow-up (see #111).

## Verified

Command shape verified against a real app: `<venv>/bin/opentelemetry-instrument <python> -m shiny run app.py` exports Shiny's `session_start`/`reactive_update`/`session_end` spans, and `--reload` is compatible (the reloaded process inherits instrumentation).

`npm run check-types` and `npm run lint` pass (the one lint warning is pre-existing in `src/assistant/extension.ts`). Not yet exercised inside a live VS Code session — please give it a spin before merging.
