### PR TITLE
Open Python Shiny apps in the Viewer pane again

### DIFF
--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -213,10 +213,22 @@ export async function openBrowserWhenReady(
   await openBrowser(previewUrl, terminal);
 }
 
+/**
+ * Reads `shiny.previewType`, resolving the `"default"` value for the Python path.
+ *
+ * The `"default"` preview type is understood by the R path (run.ts), which maps
+ * it to positron-run-app's `preview` option. The Python path reaches the browser
+ * through openBrowser / openBrowserWhenReady instead, and those don't go through
+ * that API, so an unhandled `"default"` would fall through to the Simple Browser.
+ * We treat it like `"internal"` here: Viewer pane in Positron, Simple Browser in
+ * VS Code. This restores the behavior Python apps had before `"default"` became
+ * the setting's default value.
+ */
 function configShinyPreviewType(): string {
-  return (
-    vscode.workspace.getConfiguration().get("shiny.previewType") || "internal"
-  );
+  const previewType =
+    vscode.workspace.getConfiguration().get<string>("shiny.previewType") ||
+    "internal";
+  return previewType === "default" ? "internal" : previewType;
 }
 
 /**

--- a/src/net-utils.ts
+++ b/src/net-utils.ts
@@ -8,6 +8,7 @@ import {
   type PreviewSource,
 } from "./extension-api-utils/extensionHost";
 import { getRemoteSafeUrl } from "./extension-api-utils/getRemoteSafeUrl";
+import type { PreviewMode } from "./positron-run-app";
 import { retryUntilTimeout } from "./retry-utils";
 
 /**
@@ -139,7 +140,7 @@ export async function openBrowserWhenReady(
   terminal?: vscode.Terminal,
   timeout: number = configShinyTimeoutOpenBrowser()
 ): Promise<void> {
-  if (configShinyPreviewType() === "none") {
+  if (configShinyPreviewTypeForTerminal() === "none") {
     // No need to wait for Shiny app to start or open the browser
     return;
   }
@@ -214,21 +215,41 @@ export async function openBrowserWhenReady(
 }
 
 /**
- * Reads `shiny.previewType`, resolving the `"default"` value for the Python path.
- *
- * The `"default"` preview type is understood by the R path (run.ts), which maps
- * it to positron-run-app's `preview` option. The Python path reaches the browser
- * through openBrowser / openBrowserWhenReady instead, and those don't go through
- * that API, so an unhandled `"default"` would fall through to the Simple Browser.
- * We treat it like `"internal"` here: Viewer pane in Positron, Simple Browser in
- * VS Code. This restores the behavior Python apps had before `"default"` became
- * the setting's default value.
+ * Reads `shiny.previewType` for apps run in a terminal (openBrowser /
+ * openBrowserWhenReady). This function has no positron-run-app `preview`
+ * option to defer to, so it resolves `"default"` itself, treating it like
+ * `"internal"`: Viewer pane in Positron, Simple Browser in VS Code.
  */
-function configShinyPreviewType(): string {
+function configShinyPreviewTypeForTerminal(): string {
   const previewType =
     vscode.workspace.getConfiguration().get<string>("shiny.previewType") ||
     "internal";
   return previewType === "default" ? "internal" : previewType;
+}
+
+/**
+ * Reads `shiny.previewType` for apps run via positron-run-app's console API,
+ * translating it into that API's `PreviewMode` vocabulary. `"default"` is
+ * passed through unresolved: positron-run-app understands that value itself,
+ * resolving it via its own `positron.runApp.previewMode` setting.
+ */
+export function configShinyPreviewTypeForPositronConsole(): PreviewMode | "default" {
+  const previewType =
+    vscode.workspace.getConfiguration().get<string>("shiny.previewType") ||
+    "default";
+
+  switch (previewType) {
+    case "internal":
+      return "viewer";
+    case "external":
+      return "external";
+    case "none":
+      return "none";
+    case "simple browser":
+      return "editor";
+    default:
+      return "default";
+  }
 }
 
 /**
@@ -258,7 +279,7 @@ export async function openBrowser(
   url: string,
   terminal?: vscode.Terminal
 ): Promise<void> {
-  const previewType = configShinyPreviewType();
+  const previewType = configShinyPreviewTypeForTerminal();
 
   switch (previewType) {
     case "none":

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import {
   getPositronRunAppApi,
 } from "./extension-api-utils/extensionHost";
 import {
+  configShinyPreviewTypeForPositronConsole,
   configShinyTimeoutOpenBrowser,
   openBrowser,
   openBrowserWhenReady,
@@ -253,26 +254,14 @@ function buildRConsoleCode(appPath: string, port: number, cwd: string): string {
 }
 
 export async function rRunApp(): Promise<void> {
-  const previewType =
-    vscode.workspace.getConfiguration().get<string>("shiny.previewType") || "default";
-
   const runAppApi = await getPositronRunAppApi();
   if (runAppApi) {
-    let preview: PreviewMode | "default";
-    switch (previewType) {
-      case "internal": preview = "viewer"; break;
-      case "external": preview = "external"; break;
-      case "none": preview = "none"; break;
-      case "simple browser": preview = "editor"; break;
-      default: preview = "default"; break;
-    }
-
     return runShinyAppInConsole(runAppApi, {
       language: "r",
       appUrlStrings: ["Listening on {{APP_URL}}"],
       buildCode: buildRConsoleCode,
       debugAdapterType: "ark",
-      preview,
+      preview: configShinyPreviewTypeForPositronConsole(),
     });
   }
 


### PR DESCRIPTION
Fixes posit-dev/positron#14387

In Positron, "Run Shiny App" opened Python Shiny apps in the Simple Browser instead of the Viewer pane, even though R Shiny apps opened in the Viewer pane as expected. This is a regression from #109, which changed the default of the `shiny.previewType` setting from `"internal"` to a new `"default"` value.

The R and Python run paths handle previews differently. The R path (`rRunApp`) goes through positron-run-app's API and was updated in #109 to translate `"default"` into that API's `preview` option. The Python path (`pyRunApp`) does not use that API; it reaches the browser through `openBrowser` / `openBrowserWhenReady`, whose destination is driven by `configShinyPreviewType()`. That function's `switch` had no case for `"default"`, so the new default value fell through to the Simple Browser branch. Previously the default `"internal"` hit the Viewer-pane branch.

To fix this, this PR resolves `"default"` to `"internal"` inside `configShinyPreviewType()`, which is the single point both Python-path consumers funnel through. `"internal"` already means "Viewer pane in Positron, Simple Browser in VS Code", which restores the pre-#109 behavior for Python apps:

<img width="1349" height="955" alt="Screenshot 2026-07-13 at 1 19 28 PM" src="https://github.com/user-attachments/assets/b6de82ea-3d36-47d1-b4f5-e3017f3d8dd8" />

The R path is unchanged since it handles `"default"` itself.

This would be a good candidate for an example test as we work on https://github.com/posit-dev/positron/issues/14531, cc @jonvanausdeln.
