### PR TITLE
Run Positron API tests on ubuntu-latest

### DIFF
--- a/.github/workflows/positron-api-tests.yaml
+++ b/.github/workflows/positron-api-tests.yaml
@@ -17,8 +17,7 @@ env:
 
 jobs:
   test:
-    # @posit-dev/positron-test-electron currently supports macOS only.
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -34,15 +33,16 @@ jobs:
         id: cache
         with:
           path: .positron-test
-          key: positron-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
+          key: positron-${{ runner.os }}-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
       - run: npm ci
       - name: Run Positron API tests
-        uses: posit-dev/setup-positron@main
+        uses: posit-dev/setup-positron@v1
         with:
           positron-channel: ${{ env.POSITRON_CHANNEL }}
-          run: npm run test-positron
+          # Positron is an Electron app and needs a display server on Linux.
+          run: xvfb-run -a npm run test-positron
       - uses: actions/cache/save@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
           path: .positron-test
-          key: positron-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}
+          key: positron-${{ runner.os }}-${{ env.POSITRON_CHANNEL }}-${{ steps.get-date.outputs.date }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "shiny",
       "version": "1.4.2",
       "devDependencies": {
-        "@posit-dev/positron-test-electron": "^0.0.2",
+        "@posit-dev/positron-test-electron": "^0.0.3",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "20.11.22",
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@posit-dev/positron-test-electron": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.2.tgz",
-      "integrity": "sha512-betE+lg9R6qom5cHafmimF9bJ9yWUhATj9JxzRNDAPCh9CLisQ8iSxfIv+RL+x+r7frGT0H018Y7ekb4JxW2vA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@posit-dev/positron-test-electron/-/positron-test-electron-0.0.3.tgz",
+      "integrity": "sha512-MQYKCoB9JlGd70QLV0BVTezzGljIduLskeczDLVZ/4ECuYKAtuVFHvXFLDv5BUoarSxHkc0cT6r9k7DwrSni3A==",
       "dev": true,
       "dependencies": {
         "@vscode/test-electron": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "vsix": "npx --yes @vscode/vsce package"
   },
   "devDependencies": {
-    "@posit-dev/positron-test-electron": "^0.0.2",
+    "@posit-dev/positron-test-electron": "^0.0.3",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "20.11.22",

--- a/scripts/run-positron-tests.mjs
+++ b/scripts/run-positron-tests.mjs
@@ -8,8 +8,9 @@
 // first). Set POSITRON_CHANNEL=daily to test against a daily Positron build
 // (default: stable).
 //
-// NOTE: @posit-dev/positron-test-electron currently supports macOS only;
-// Windows/Linux support is planned upstream.
+// NOTE: on Linux, Positron is an Electron app and needs a display server, so
+// wrap the command in `xvfb-run` when running headless (as the "Positron API
+// Tests" GitHub Actions workflow does).
 
 import { runTests } from "@posit-dev/positron-test-electron";
 import * as path from "node:path";

--- a/src/test/positron/README.md
+++ b/src/test/positron/README.md
@@ -37,10 +37,15 @@ npm run test-positron                          # against the latest stable Posit
 POSITRON_CHANNEL=daily npm run test-positron   # against a daily build
 ```
 
-> **Note:** `@posit-dev/positron-test-electron` currently supports **macOS
-> only**. On other platforms, rely on the `Positron API Tests` GitHub Actions
-> workflow (`.github/workflows/positron-api-tests.yaml`), which runs on every
-> PR and push to `main`.
+On Linux, Positron needs a display server, so run it under `xvfb-run` when
+headless:
+
+```bash
+xvfb-run -a npm run test-positron
+```
+
+> **Note:** the suite also runs in CI on every PR and push to `main` via the
+> `Positron API Tests` workflow (`.github/workflows/positron-api-tests.yaml`).
 
 ## Adding tests
 


### PR DESCRIPTION
Follow-up to #115 and posit-dev/positron#15281: now that Positron ships Linux builds, move the `Positron API Tests` job off the macOS runner (which bills at 10x the Linux rate) to `ubuntu-latest`, and pin `setup-positron` to `@v1` so upstream changes to the action can't break CI here.

Not purely a workflow-file change:

- **`@posit-dev/positron-test-electron` bumped to `^0.0.3`.** `0.0.2`'s platform table only has `darwin-arm64`/`darwin-x64`; the Linux descriptors land in `0.0.3`.
- **`xvfb-run` is required.** Positron is an Electron app, so on Linux the test command needs a display server — without it the run dies with `Missing X server or $DISPLAY` and then `SIGSEGV`. `setup-positron`'s `action.yml` is a thin composite step that just runs the given command, so it doesn't provide one.

Also keys the Positron download cache by `runner.os` so the macOS and Linux archives can't collide.

The local-run notes in `scripts/run-positron-tests.mjs` and `src/test/positron/README.md` no longer say macOS-only; they point at `xvfb-run` for headless Linux instead.

Verified by the `Positron API Tests` check on this PR.